### PR TITLE
Make the sevenzip extractor use 7z instead of 7zz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,6 @@ RUN --mount=from=ghcr.io/astral-sh/uv:latest,source=/uv,target=/bin/uv \
     libssl-dev \
     libfontconfig1-dev \
     libpython3-dev \
-    7zip-standalone \
     cpio \
     device-tree-compiler \
     clang \

--- a/dependencies/ubuntu.sh
+++ b/dependencies/ubuntu.sh
@@ -30,7 +30,6 @@ DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install \
     libfontconfig1-dev \
     liblzma-dev \
     libssl-dev \
-    7zip-standalone \
     cpio \
     device-tree-compiler
 

--- a/src/formats/sevenzip.rs
+++ b/src/formats/sevenzip.rs
@@ -127,7 +127,7 @@ pub fn parse_7z_header(sevenzip_data: &[u8]) -> Result<SevenZipHeader, Structure
 /// ```
 pub fn sevenzip_extractor() -> extractors::Extractor {
     extractors::Extractor {
-        utility: extractors::ExtractorType::External("7zz".to_string()),
+        utility: extractors::ExtractorType::External("7z".to_string()),
         extension: "bin".to_string(),
         arguments: vec![
             "x".to_string(),    // Perform extraction


### PR DESCRIPTION
The `7z` binary is more common, and currently we use the less common 7zip-standalone (using the `7zz` binary).

Some Linux distros (for example Arch Linux) don't even provide the 7zip-standalone package and the `7zz` binary.

Also, the current Dockerfile installs both packages for no apparent reason.