### PR TITLE
refactor: use the library crate from the binary

### DIFF
--- a/src/binwalk_ng.rs
+++ b/src/binwalk_ng.rs
@@ -96,7 +96,6 @@ impl Binwalk {
     ///
     /// let binwalker = Binwalk::new();
     /// ```
-    #[allow(dead_code)]
     pub fn new() -> Self {
         Self::configure(None, None, vec![], vec![], None, false).unwrap()
     }
@@ -774,7 +773,6 @@ impl Binwalk {
     /// # Ok(binwalker)
     /// # } _doctest_main_src_binwalk_rs_745_0(); }
     /// ```
-    #[allow(dead_code)]
     pub fn analyze(&self, target_file: impl AsRef<Path>, do_extraction: bool) -> AnalysisResults {
         let file_path = target_file.as_ref();
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,6 @@
-use crate::binwalk_ng::AnalysisResults;
-use crate::extractors;
-use crate::signatures;
+use binwalk_ng::AnalysisResults;
+use binwalk_ng::extractors;
+use binwalk_ng::signatures;
 use colored::ColoredString;
 use colored::Colorize;
 use log::error;

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -718,7 +718,6 @@ impl Chroot {
     ///
     /// assert_eq!(chroot.make_executable(file_name), true);
     /// ```
-    #[allow(dead_code)]
     pub fn make_executable(&self, file_path: impl AsRef<Path>) -> bool {
         // Make the file globally executable
         const UNIX_EXEC_FLAG: u32 = 1;

--- a/src/json.rs
+++ b/src/json.rs
@@ -7,10 +7,10 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::binwalk_ng::AnalysisResults;
 use crate::display;
 #[cfg(feature = "entropy-plot")]
 use crate::entropy::FileEntropy;
+use binwalk_ng::AnalysisResults;
 
 const STDOUT: &str = "-";
 const JSON_LIST_START: &str = "[\n";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod binwalk_ng;
 pub mod common;
 pub mod extractors;
 pub mod formats;
-mod magic;
+pub mod magic;
 pub mod signatures;
 pub mod structures;
 pub use binwalk_ng::{AnalysisResults, Binwalk, BinwalkError};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use binwalk_ng::AnalysisResults;
+use binwalk_ng::extractors::Chroot;
+use binwalk_ng::{AnalysisResults, common, extractors};
 use clap::Parser;
 use log::{debug, error, info};
 use std::collections::VecDeque;
@@ -12,18 +13,11 @@ use std::thread;
 use std::time;
 use threadpool::ThreadPool;
 
-mod binwalk_ng;
 mod cli_parser;
-mod common;
 mod display;
 #[cfg(feature = "entropy-plot")]
 mod entropy;
-mod extractors;
-mod formats;
 mod json;
-mod magic;
-mod signatures;
-mod structures;
 
 fn main() -> ExitCode {
     // Only use one thread if unable to auto-detect available core info
@@ -60,7 +54,7 @@ fn main() -> ExitCode {
 
     // If --list was specified, just display a list of signatures and return
     if cli_args.list {
-        display::print_signature_list(cli_args.quiet, &magic::patterns());
+        display::print_signature_list(cli_args.quiet, &binwalk_ng::magic::patterns());
         return ExitCode::SUCCESS;
     }
 
@@ -377,7 +371,7 @@ fn carve_file_data_to_disk(
     offset: usize,
     size: usize,
 ) -> bool {
-    let chroot = extractors::Chroot::default();
+    let chroot = Chroot::default();
 
     // Carved file path will be: <source file path>_<offset>_<name>.raw
     let carved_file_path = format!(


### PR DESCRIPTION
The binary declared its own `mod` entries for common, extractors, magic, signatures, formats, structures, and binwalk_ng, which compiled the entire core a second time as part of the binary crate.

The binary automatically depends on the library crate, so import the shared modules from it, rather than re-declaring the same modules. Promote `magic` to `pub` in lib.rs so it is reachable, and update display.rs/json.rs to the external `binwalk_ng::AnalysisResults` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal imports to reference shared library components directly for consistency.
  * Simplified the application’s module usage and adjusted related calls to use the library’s public interfaces.
* **New Features**
  * Expanded the library’s public API by making the `magic` module publicly accessible.
* **Chores**
  * Removed unnecessary warning-suppression annotations around previously unused methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->