### PR TITLE
chore(docker): remove apt packages unused by build, runtime, or code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,11 @@ RUN apt-get update -y \
     tzdata \
     curl \
     git \
-    wget \
     build-essential \
     clang \
     zlib1g \
     zlib1g-dev \
     liblz4-1 \
-    libsrecord-dev \
     liblzma-dev \
     liblzo2-dev \
     libucl-dev \
@@ -101,17 +99,13 @@ RUN --mount=from=ghcr.io/astral-sh/uv:latest,source=/uv,target=/bin/uv \
     zlib1g \
     zlib1g-dev \
     liblz4-1 \
-    libsrecord-dev \
     liblzma-dev \
     liblzo2-dev \
     libucl-dev \
     liblz4-dev \
     libbz2-dev \
     libssl-dev \
-    libfontconfig1-dev \
     libpython3-dev \
-    cpio \
-    device-tree-compiler \
     clang \
     && dpkg -i /tmp/sasquatch.deb \
     && CC=clang uv pip install --system --break-system-packages uefi_firmware jefferson ubi-reader vmlinux-to-elf \


### PR DESCRIPTION
## What

Removes 5 apt packages from the Dockerfile that no build step, runtime tool, or code path uses:

| Package | Why it's safe to remove |
|---|---|
| `wget` | The Dockerfile only fetches via `curl` and `git clone`. |
| `libsrecord-dev` | binwalk shells out to the `srec_cat` **binary** (from `srecord`, still installed); nothing links `libsrecord`. |
| `libfontconfig1-dev` | Only needed by `plotly`/`kaleido`, which is behind the non-default `entropy-plot` feature and isn't compiled in the image. |
| `cpio` | No cpio external extractor is invoked — `src/formats/cpio.rs` is parse-only; there's no `ExtractorType::External("cpio")`. |
| `device-tree-compiler` | DTB extraction is an internal Rust extractor (`dtb_extractor` → `Internal`); `dtc`/`fdtdump` are never called. |

## Kept (initially mis-flagged, caught by the build)

`libucl-dev` is **kept** — the source-built `dumpifs` tool links UCL (`clang … -lucl`, `#include <ucl/ucl.h>`) at build time and needs `libucl1` at runtime.

## Validation

Built the `dev` image from this Dockerfile and ran the full CI suite inside it:

```
docker build --target dev -t binwalk:dev .
docker run --rm -v "$PWD:/tmp/binwalk" -e CI=true -e INSTA_UPDATE=new binwalk:dev \
  cargo insta test --unreferenced=reject
```

Result: **191 passed, 0 failed, 3 ignored**; no unreferenced snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by removing unused dependencies from build and runtime stages, resulting in reduced image size and improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->