### PR TITLE
feat(yaffs): internal Rust YAFFS2 extractor, drop unyaffs dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,6 @@ RUN --mount=from=ghcr.io/astral-sh/uv:latest,source=/uv,target=/bin/uv \
     lz4 \
     lzop \
     unrar \
-    unyaffs \
     zlib1g \
     zlib1g-dev \
     liblz4-1 \

--- a/dependencies/ubuntu.sh
+++ b/dependencies/ubuntu.sh
@@ -17,7 +17,6 @@ DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install \
     lz4 \
     lzop \
     unrar \
-    unyaffs \
     python3-pip \
     build-essential \
     clang \

--- a/src/formats/yaffs.rs
+++ b/src/formats/yaffs.rs
@@ -1,7 +1,10 @@
 use crate::common::is_offset_safe;
 use crate::extractors;
+use crate::extractors::{Chroot, ExtractionResult};
 use crate::signatures::{CONFIDENCE_MEDIUM, SignatureError, SignatureResult};
 use crate::structures::{Endianness, StructureError, dyn_endian};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 
 /// Minimum number of expected YAFFS objects in a YAFFS image
@@ -289,37 +292,462 @@ pub fn parse_yaffs_file_header(
     })
 }
 
-/// Describes how to run the unyaffs utility to extract YAFFS2 file systems
+/// Defines the internal extractor for YAFFS2 file systems.
+///
+/// The image is unpacked directly in Rust (no external `unyaffs` dependency) through the
+/// chroot-safe `Chroot` API, so object paths cannot escape the extraction directory.
 ///
 /// ```
-/// use std::io::ErrorKind;
-/// use std::process::Command;
 /// use binwalk_ng::extractors::ExtractorType;
 /// use binwalk_ng::formats::yaffs::yaffs2_extractor;
 ///
 /// match yaffs2_extractor().utility {
-///     ExtractorType::None => panic!("Invalid extractor type of None"),
-///     ExtractorType::Internal(func) => println!("Internal extractor OK: {:?}", func),
-///     ExtractorType::External(cmd) => {
-///         if let Err(e) = Command::new(&cmd).output() {
-///             if e.kind() == ErrorKind::NotFound {
-///                 panic!("External extractor '{}' not found", cmd);
-///             } else {
-///                 panic!("Failed to execute external extractor '{}': {}", cmd, e);
-///             }
-///         }
-///     }
+///     ExtractorType::Internal(_) => {}
+///     _ => panic!("yaffs extractor should be internal"),
 /// }
 /// ```
 pub fn yaffs2_extractor() -> extractors::Extractor {
     extractors::Extractor {
-        utility: extractors::ExtractorType::External("unyaffs".to_string()),
-        extension: "img".to_string(),
-        arguments: vec![
-            extractors::SOURCE_FILE_PLACEHOLDER.to_string(),
-            "yaffs-root".to_string(),
-        ],
-        exit_codes: vec![0],
+        utility: extractors::ExtractorType::Internal(extract_yaffs),
         ..Default::default()
+    }
+}
+
+/// Metadata parsed from a YAFFS object header, used to reconstruct the file tree.
+#[derive(Debug, Clone, Default)]
+struct YaffsObjectInfo {
+    obj_type: u32,
+    parent_id: u32,
+    name: String,
+    /// Symlink target (only meaningful for symlink objects)
+    alias: String,
+    /// Object id this hardlink points at (only meaningful for hardlink objects)
+    equiv_id: u32,
+    /// Unix mode bits (used to distinguish special-file types)
+    mode: u32,
+    /// Packed device numbers (only meaningful for special objects)
+    rdev: u32,
+}
+
+/// Internal extractor: reconstructs the YAFFS2 file tree directly in Rust (a port of the
+/// `unyaffs` utility's logic, generalized to the page/spare geometry detected by the
+/// signature parser).
+///
+/// The image is a sequence of fixed-size chunks, each made up of `page_size` bytes of data
+/// followed by a `spare_size`-byte spare/OOB area. The spare begins with the packed tags
+/// (sequence number, object id, chunk id, byte count). A chunk id of 0 marks an object
+/// header (file/dir/symlink/hardlink/special); chunk ids greater than 0 carry file data,
+/// where chunk id `N` holds the `N`-th `page_size`-byte block of the file. Object ids from
+/// the tags are mapped to each object's parent and name (from the headers) to rebuild full
+/// paths, which are written out through the chroot-safe `Chroot` API.
+///
+/// When `output_directory` is `None`, this performs a dry run (parse/validate only, nothing
+/// is written to disk).
+fn extract_yaffs(
+    file_data: &[u8],
+    offset: usize,
+    output_directory: Option<&Path>,
+) -> ExtractionResult {
+    const ROOT_OBJECT_ID: u32 = 1;
+    const UNUSED_OBJECT_ID: u32 = 0xFFFF_FFFF;
+    const TAG_OBJECT_ID: usize = 4;
+    const TAG_CHUNK_ID: usize = 8;
+    const TAG_BYTE_COUNT: usize = 12;
+
+    let mut result = ExtractionResult::default();
+
+    let Some(data) = file_data.get(offset..) else {
+        return result;
+    };
+    let Some(&first_byte) = data.first() else {
+        return result;
+    };
+
+    // A big-endian image starts with the high byte of the (little) object type field == 0.
+    let endianness = if first_byte == 0 {
+        Endianness::Big
+    } else {
+        Endianness::Little
+    };
+
+    // Reuse the signature parser's geometry/size detection.
+    let Ok(page_size) = get_page_size(data) else {
+        return result;
+    };
+    let Ok(spare_size) = get_spare_size(data, page_size, endianness) else {
+        return result;
+    };
+    let Ok(image_size) = get_image_size(data, page_size, spare_size, endianness) else {
+        return result;
+    };
+
+    let block_size = page_size + spare_size;
+    let chunk_count = image_size / block_size;
+
+    // object id -> parsed header metadata
+    let mut objects: BTreeMap<u32, YaffsObjectInfo> = BTreeMap::new();
+    // object id -> (chunk id, valid data bytes) for file content chunks
+    let mut file_chunks: BTreeMap<u32, Vec<(u32, Vec<u8>)>> = BTreeMap::new();
+
+    for chunk_index in 0..chunk_count {
+        let block_offset = chunk_index * block_size;
+        let Some(page) = data.get(block_offset..block_offset + page_size) else {
+            break;
+        };
+        let Some(spare) = data.get(block_offset + page_size..block_offset + block_size) else {
+            break;
+        };
+
+        let Some(object_id) = read_u32(spare, TAG_OBJECT_ID, endianness) else {
+            continue;
+        };
+        let Some(chunk_id) = read_u32(spare, TAG_CHUNK_ID, endianness) else {
+            continue;
+        };
+
+        // Skip erased / unused chunks.
+        if object_id == 0 || object_id == UNUSED_OBJECT_ID {
+            continue;
+        }
+
+        if chunk_id == 0 {
+            // Object header chunk.
+            if let Some(object) = parse_full_object_header(page, endianness) {
+                objects.insert(object_id, object);
+            }
+        } else {
+            // File data chunk: only `byte_count` bytes of the page are valid (the final
+            // chunk of a file is usually partial).
+            let byte_count = read_u32(spare, TAG_BYTE_COUNT, endianness).unwrap_or(0) as usize;
+            let valid_len = byte_count.min(page_size);
+            if let Some(chunk_bytes) = page.get(..valid_len) {
+                file_chunks
+                    .entry(object_id)
+                    .or_default()
+                    .push((chunk_id, chunk_bytes.to_vec()));
+            }
+        }
+    }
+
+    if objects.is_empty() {
+        return result;
+    }
+
+    let chroot = output_directory.map(Chroot::new);
+    let object_ids: Vec<u32> = objects.keys().copied().collect();
+    let mut extracted_something = false;
+
+    for object_id in object_ids {
+        if object_id == ROOT_OBJECT_ID {
+            continue;
+        }
+        let Some(path) = resolve_object_path(object_id, &objects) else {
+            continue;
+        };
+
+        // Dry run: validate only, don't touch the filesystem.
+        let Some(chroot) = &chroot else {
+            extracted_something = true;
+            continue;
+        };
+
+        if write_object(chroot, object_id, &path, &objects, &mut file_chunks) {
+            extracted_something = true;
+        }
+    }
+
+    if extracted_something {
+        result.success = true;
+        result.size = Some(image_size);
+    }
+
+    result
+}
+
+/// Write a single parsed object (file/dir/symlink/hardlink/special) into the chroot.
+fn write_object(
+    chroot: &Chroot,
+    object_id: u32,
+    path: &Path,
+    objects: &BTreeMap<u32, YaffsObjectInfo>,
+    file_chunks: &mut BTreeMap<u32, Vec<(u32, Vec<u8>)>>,
+) -> bool {
+    // yaffs_obj_type enum values
+    const FILE: u32 = 1;
+    const SYMLINK: u32 = 2;
+    const DIRECTORY: u32 = 3;
+    const HARDLINK: u32 = 4;
+    const SPECIAL: u32 = 5;
+
+    let Some(object) = objects.get(&object_id) else {
+        return false;
+    };
+
+    // Ensure the parent directory exists (paths may be nested).
+    if let Some(parent) = path.parent() {
+        chroot.create_directory(parent);
+    }
+
+    match object.obj_type {
+        DIRECTORY => chroot.create_directory(path),
+        SYMLINK => chroot.create_symlink(path, &object.alias),
+        // The Chroot API has no hardlink primitive; represent a hardlink as a symlink to
+        // its target object, mirroring how the tarball extractor handles hardlinks.
+        HARDLINK => resolve_object_path(object.equiv_id, objects)
+            .is_some_and(|target| chroot.create_symlink(path, &target)),
+        FILE => {
+            // Concatenate the file's data chunks in chunk-id order.
+            let mut chunks = file_chunks.remove(&object_id).unwrap_or_default();
+            chunks.sort_by_key(|(chunk_id, _)| *chunk_id);
+            let mut contents = Vec::new();
+            for (_, bytes) in chunks {
+                contents.extend_from_slice(&bytes);
+            }
+            chroot.create_file(path, &contents)
+        }
+        SPECIAL => create_special_file(chroot, path, object),
+        // Unknown object type: nothing to write.
+        _ => false,
+    }
+}
+
+/// Create a placeholder for a YAFFS special file (device node / fifo / socket), using the
+/// object's mode bits to pick the kind. As with the other extractors, device nodes are
+/// represented as regular files describing the device rather than real device nodes.
+fn create_special_file(chroot: &Chroot, path: &Path, object: &YaffsObjectInfo) -> bool {
+    // S_IFMT file-type bits
+    const S_IFMT: u32 = 0o170_000;
+    const S_IFSOCK: u32 = 0o140_000;
+    const S_IFBLK: u32 = 0o060_000;
+    const S_IFCHR: u32 = 0o020_000;
+
+    let major = ((object.rdev >> 8) & 0xff) as usize;
+    let minor = (object.rdev & 0xff) as usize;
+
+    match object.mode & S_IFMT {
+        S_IFCHR => chroot.create_character_device(path, major, minor),
+        S_IFBLK => chroot.create_block_device(path, major, minor),
+        S_IFSOCK => chroot.create_socket(path),
+        // Treat fifos and anything else as a fifo placeholder.
+        _ => chroot.create_fifo(path),
+    }
+}
+
+/// Fully parse a YAFFS object header from a header chunk's page data.
+fn parse_full_object_header(page: &[u8], endianness: Endianness) -> Option<YaffsObjectInfo> {
+    const NAME_OFFSET: usize = 10;
+    const NAME_MAX_LEN: usize = 256;
+    const MODE_OFFSET: usize = 268;
+    const EQUIV_ID_OFFSET: usize = 296;
+    const ALIAS_OFFSET: usize = 300;
+    const ALIAS_MAX_LEN: usize = 160;
+    const RDEV_OFFSET: usize = 460;
+    const MAX_OBJ_TYPE: u32 = 5;
+
+    let obj_type = read_u32(page, 0, endianness)?;
+    let parent_id = read_u32(page, 4, endianness)?;
+
+    // Mirror parse_yaffs_obj_header's sanity checks.
+    if obj_type > MAX_OBJ_TYPE || parent_id == 0 {
+        return None;
+    }
+
+    Some(YaffsObjectInfo {
+        obj_type,
+        parent_id,
+        name: read_cstring(page, NAME_OFFSET, NAME_MAX_LEN),
+        alias: read_cstring(page, ALIAS_OFFSET, ALIAS_MAX_LEN),
+        equiv_id: read_u32(page, EQUIV_ID_OFFSET, endianness).unwrap_or(0),
+        mode: read_u32(page, MODE_OFFSET, endianness).unwrap_or(0),
+        rdev: read_u32(page, RDEV_OFFSET, endianness).unwrap_or(0),
+    })
+}
+
+/// Resolve an object's full (relative) path by walking the parent chain up to the root.
+fn resolve_object_path(
+    object_id: u32,
+    objects: &BTreeMap<u32, YaffsObjectInfo>,
+) -> Option<PathBuf> {
+    const ROOT_OBJECT_ID: u32 = 1;
+    // Bounds the walk so a corrupt/cyclic parent chain cannot loop forever.
+    const MAX_PATH_DEPTH: usize = 1000;
+
+    let mut components: Vec<&str> = Vec::new();
+    let mut current_id = object_id;
+
+    for _ in 0..MAX_PATH_DEPTH {
+        if current_id == ROOT_OBJECT_ID {
+            let mut path = PathBuf::new();
+            for component in components.iter().rev() {
+                path.push(component);
+            }
+            return Some(path);
+        }
+
+        let object = objects.get(&current_id)?;
+        if object.name.is_empty() {
+            return None;
+        }
+        components.push(&object.name);
+        current_id = object.parent_id;
+    }
+
+    None
+}
+
+/// Read a little/big-endian `u32` at `offset`, returning `None` if out of bounds.
+fn read_u32(data: &[u8], offset: usize, endianness: Endianness) -> Option<u32> {
+    let bytes: [u8; 4] = data.get(offset..offset + 4)?.try_into().ok()?;
+    Some(match endianness {
+        Endianness::Big => u32::from_be_bytes(bytes),
+        Endianness::Little => u32::from_le_bytes(bytes),
+    })
+}
+
+/// Read a NUL-terminated string of at most `max_len` bytes starting at `offset`.
+fn read_cstring(data: &[u8], offset: usize, max_len: usize) -> String {
+    let end = offset.saturating_add(max_len).min(data.len());
+    let field = data.get(offset..end).unwrap_or(&[]);
+    let string_len = field.iter().position(|&b| b == 0).unwrap_or(field.len());
+    String::from_utf8_lossy(&field[..string_len]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shared test fixture: a little-endian YAFFS2 image (page size 2048, spare size 64)
+    /// containing 13 regular files in the root directory (the yaffs source headers used to
+    /// build it). Image size is 126720 bytes; the file has trailing padding past that.
+    const FIXTURE: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/inputs/yaffs2.bin"
+    ));
+    const IMAGE_SIZE: usize = 126720;
+
+    #[test]
+    fn detects_page_and_spare_size() {
+        assert_eq!(get_page_size(FIXTURE).unwrap(), 2048);
+        assert_eq!(
+            get_spare_size(FIXTURE, 2048, Endianness::Little).unwrap(),
+            64
+        );
+    }
+
+    #[test]
+    fn parser_reports_image_geometry() {
+        let result = yaffs_parser(FIXTURE, 0).unwrap();
+        assert_eq!(result.offset, 0);
+        assert_eq!(result.size, IMAGE_SIZE);
+        assert!(result.description.contains("page size: 2048"));
+        assert!(result.description.contains("spare size: 64"));
+        assert!(result.description.contains("Little"));
+    }
+
+    #[test]
+    fn first_object_header_is_a_file() {
+        // The first chunk is an object header for a regular file (yaffs type 1).
+        let object = parse_yaffs_obj_header(FIXTURE, Endianness::Little).unwrap();
+        assert_eq!(object.obj_type, 1);
+
+        let full = parse_full_object_header(&FIXTURE[..2048], Endianness::Little).unwrap();
+        assert_eq!(full.obj_type, 1);
+        assert_eq!(full.parent_id, 1); // lives in the root directory
+        assert!(!full.name.is_empty());
+    }
+
+    #[test]
+    fn read_u32_respects_endianness() {
+        let bytes = [0x01, 0x02, 0x03, 0x04];
+        assert_eq!(
+            read_u32(&bytes, 0, Endianness::Little).unwrap(),
+            0x0403_0201
+        );
+        assert_eq!(read_u32(&bytes, 0, Endianness::Big).unwrap(), 0x0102_0304);
+        // Out-of-bounds reads return None rather than panicking.
+        assert!(read_u32(&bytes, 2, Endianness::Little).is_none());
+    }
+
+    #[test]
+    fn read_cstring_stops_at_nul() {
+        let bytes = b"hello\x00world";
+        assert_eq!(read_cstring(bytes, 0, 11), "hello");
+        assert_eq!(read_cstring(bytes, 6, 5), "world");
+        // A field with no NUL is read up to max_len / end of slice.
+        assert_eq!(read_cstring(b"abc", 0, 8), "abc");
+    }
+
+    #[test]
+    fn resolve_path_walks_parent_chain() {
+        let mut objects = BTreeMap::new();
+        objects.insert(
+            10,
+            YaffsObjectInfo {
+                obj_type: 3,
+                parent_id: 1,
+                name: "dir".to_string(),
+                ..Default::default()
+            },
+        );
+        objects.insert(
+            11,
+            YaffsObjectInfo {
+                obj_type: 1,
+                parent_id: 10,
+                name: "file.txt".to_string(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            resolve_object_path(10, &objects).unwrap(),
+            PathBuf::from("dir")
+        );
+        assert_eq!(
+            resolve_object_path(11, &objects).unwrap(),
+            PathBuf::from("dir").join("file.txt")
+        );
+        // An object whose parent chain never reaches the root is rejected.
+        let mut orphan = BTreeMap::new();
+        orphan.insert(
+            5,
+            YaffsObjectInfo {
+                obj_type: 1,
+                parent_id: 999,
+                name: "lost".to_string(),
+                ..Default::default()
+            },
+        );
+        assert!(resolve_object_path(5, &orphan).is_none());
+    }
+
+    #[test]
+    fn dry_run_validates_without_writing() {
+        let result = extract_yaffs(FIXTURE, 0, None);
+        assert!(result.success);
+        assert_eq!(result.size, Some(IMAGE_SIZE));
+    }
+
+    #[test]
+    fn extracts_all_files_to_disk() {
+        let output = tempfile::tempdir().unwrap();
+        let result = extract_yaffs(FIXTURE, 0, Some(output.path()));
+        assert!(result.success);
+        assert_eq!(result.size, Some(IMAGE_SIZE));
+
+        // The fixture holds 13 regular files, all in the root directory.
+        let entries: Vec<_> = std::fs::read_dir(output.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert_eq!(entries.len(), 13);
+
+        // Spot-check two recognizable files and their exact sizes.
+        let guts = output.path().join("yaffs_guts.h");
+        assert!(guts.is_file());
+        assert_eq!(std::fs::metadata(&guts).unwrap().len(), 27266);
+
+        let mk = output.path().join("mkyaffs2image.c");
+        assert!(mk.is_file());
+        assert_eq!(std::fs::metadata(&mk).unwrap().len(), 15107);
     }
 }

--- a/src/formats/yaffs.rs
+++ b/src/formats/yaffs.rs
@@ -327,6 +327,8 @@ struct YaffsObjectInfo {
     mode: u32,
     /// Packed device numbers (only meaningful for special objects)
     rdev: u32,
+    /// Declared file size in bytes (only meaningful for regular files)
+    file_size: usize,
 }
 
 /// Internal extractor: reconstructs the YAFFS2 file tree directly in Rust (a port of the
@@ -350,6 +352,7 @@ fn extract_yaffs(
 ) -> ExtractionResult {
     const ROOT_OBJECT_ID: u32 = 1;
     const UNUSED_OBJECT_ID: u32 = 0xFFFF_FFFF;
+    const TAG_SEQUENCE_NUMBER: usize = 0;
     const TAG_OBJECT_ID: usize = 4;
     const TAG_CHUNK_ID: usize = 8;
     const TAG_BYTE_COUNT: usize = 12;
@@ -384,10 +387,11 @@ fn extract_yaffs(
     let block_size = page_size + spare_size;
     let chunk_count = image_size / block_size;
 
-    // object id -> parsed header metadata
+    // object id -> parsed header metadata, plus the sequence number it came from
     let mut objects: BTreeMap<u32, YaffsObjectInfo> = BTreeMap::new();
-    // object id -> (chunk id, valid data bytes) for file content chunks
-    let mut file_chunks: BTreeMap<u32, Vec<(u32, Vec<u8>)>> = BTreeMap::new();
+    let mut header_sequence: BTreeMap<u32, u32> = BTreeMap::new();
+    // object id -> (chunk id -> (sequence number, valid data bytes)) for file content
+    let mut file_chunks: BTreeMap<u32, BTreeMap<u32, (u32, Vec<u8>)>> = BTreeMap::new();
 
     for chunk_index in 0..chunk_count {
         let block_offset = chunk_index * block_size;
@@ -398,6 +402,9 @@ fn extract_yaffs(
             break;
         };
 
+        let Some(sequence) = read_u32(spare, TAG_SEQUENCE_NUMBER, endianness) else {
+            continue;
+        };
         let Some(object_id) = read_u32(spare, TAG_OBJECT_ID, endianness) else {
             continue;
         };
@@ -410,10 +417,18 @@ fn extract_yaffs(
             continue;
         }
 
+        // YAFFS is log-structured: superseded pages are left in place, so for each
+        // logical page keep the version with the highest sequence number (ties resolve
+        // to the later physical page, matching how unyaffs replays the image in order).
         if chunk_id == 0 {
             // Object header chunk.
-            if let Some(object) = parse_full_object_header(page, endianness) {
+            let is_newest = match header_sequence.get(&object_id) {
+                Some(&previous) => sequence >= previous,
+                None => true,
+            };
+            if is_newest && let Some(object) = parse_full_object_header(page, endianness) {
                 objects.insert(object_id, object);
+                header_sequence.insert(object_id, sequence);
             }
         } else {
             // File data chunk: only `byte_count` bytes of the page are valid (the final
@@ -421,10 +436,14 @@ fn extract_yaffs(
             let byte_count = read_u32(spare, TAG_BYTE_COUNT, endianness).unwrap_or(0) as usize;
             let valid_len = byte_count.min(page_size);
             if let Some(chunk_bytes) = page.get(..valid_len) {
-                file_chunks
-                    .entry(object_id)
-                    .or_default()
-                    .push((chunk_id, chunk_bytes.to_vec()));
+                let entry = file_chunks.entry(object_id).or_default();
+                let is_newest = match entry.get(&chunk_id) {
+                    Some((previous, _)) => sequence >= *previous,
+                    None => true,
+                };
+                if is_newest {
+                    entry.insert(chunk_id, (sequence, chunk_bytes.to_vec()));
+                }
             }
         }
     }
@@ -451,7 +470,14 @@ fn extract_yaffs(
             continue;
         };
 
-        if write_object(chroot, object_id, &path, &objects, &mut file_chunks) {
+        if write_object(
+            chroot,
+            object_id,
+            &path,
+            &objects,
+            &mut file_chunks,
+            page_size,
+        ) {
             extracted_something = true;
         }
     }
@@ -470,7 +496,8 @@ fn write_object(
     object_id: u32,
     path: &Path,
     objects: &BTreeMap<u32, YaffsObjectInfo>,
-    file_chunks: &mut BTreeMap<u32, Vec<(u32, Vec<u8>)>>,
+    file_chunks: &mut BTreeMap<u32, BTreeMap<u32, (u32, Vec<u8>)>>,
+    page_size: usize,
 ) -> bool {
     // yaffs_obj_type enum values
     const FILE: u32 = 1;
@@ -493,22 +520,68 @@ fn write_object(
         SYMLINK => chroot.create_symlink(path, &object.alias),
         // The Chroot API has no hardlink primitive; represent a hardlink as a symlink to
         // its target object, mirroring how the tarball extractor handles hardlinks.
+        // resolve_object_path returns a path relative to the extraction root, so anchor
+        // it at "/": create_symlink resolves a *relative* target against the symlink's
+        // own parent directory, which would aim a nested hardlink at the wrong place.
         HARDLINK => resolve_object_path(object.equiv_id, objects)
-            .is_some_and(|target| chroot.create_symlink(path, &target)),
+            .is_some_and(|target| chroot.create_symlink(path, Path::new("/").join(target))),
         FILE => {
-            // Concatenate the file's data chunks in chunk-id order.
-            let mut chunks = file_chunks.remove(&object_id).unwrap_or_default();
-            chunks.sort_by_key(|(chunk_id, _)| *chunk_id);
-            let mut contents = Vec::new();
-            for (_, bytes) in chunks {
-                contents.extend_from_slice(&bytes);
-            }
+            let contents =
+                materialize_file(file_chunks.remove(&object_id), object.file_size, page_size);
             chroot.create_file(path, &contents)
         }
         SPECIAL => create_special_file(chroot, path, object),
         // Unknown object type: nothing to write.
         _ => false,
     }
+}
+
+/// Reassemble a regular file's contents by placing each data chunk at its logical offset
+/// `(chunk_id - 1) * page_size`, zero-filling any holes between chunks.
+///
+/// The buffer length is bounded by the data actually present (then truncated to the
+/// declared `file_size` when that is smaller), so a corrupt size field cannot trigger a
+/// huge allocation — mirroring the tarball extractor's "don't trust the header size"
+/// stance while still honoring chunk positions and the partial final page.
+fn materialize_file(
+    chunks: Option<BTreeMap<u32, (u32, Vec<u8>)>>,
+    file_size: usize,
+    page_size: usize,
+) -> Vec<u8> {
+    let chunks = chunks.unwrap_or_default();
+
+    // Furthest byte any present chunk reaches (the final chunk's tag byte count already
+    // encodes the partial last page).
+    let content_end = chunks
+        .iter()
+        .map(|(&chunk_id, (_seq, bytes))| {
+            (chunk_id as usize)
+                .saturating_sub(1)
+                .saturating_mul(page_size)
+                .saturating_add(bytes.len())
+        })
+        .max()
+        .unwrap_or(0);
+
+    // Logical length: the declared size, but never larger than the chunk data supports.
+    let len = if file_size == 0 {
+        content_end
+    } else {
+        file_size.min(content_end)
+    };
+
+    let mut contents = vec![0u8; len];
+    for (chunk_id, (_seq, bytes)) in chunks {
+        let start = (chunk_id as usize)
+            .saturating_sub(1)
+            .saturating_mul(page_size);
+        if start >= len {
+            continue;
+        }
+        let copy_len = bytes.len().min(len - start);
+        contents[start..start + copy_len].copy_from_slice(&bytes[..copy_len]);
+    }
+    contents
 }
 
 /// Create a placeholder for a YAFFS special file (device node / fifo / socket), using the
@@ -535,20 +608,26 @@ fn create_special_file(chroot: &Chroot, path: &Path, object: &YaffsObjectInfo) -
 
 /// Fully parse a YAFFS object header from a header chunk's page data.
 fn parse_full_object_header(page: &[u8], endianness: Endianness) -> Option<YaffsObjectInfo> {
+    const NAME_CHECKSUM_OFFSET: usize = 8;
     const NAME_OFFSET: usize = 10;
     const NAME_MAX_LEN: usize = 256;
     const MODE_OFFSET: usize = 268;
+    const FILE_SIZE_OFFSET: usize = 292;
     const EQUIV_ID_OFFSET: usize = 296;
     const ALIAS_OFFSET: usize = 300;
     const ALIAS_MAX_LEN: usize = 160;
     const RDEV_OFFSET: usize = 460;
     const MAX_OBJ_TYPE: u32 = 5;
+    // The name-checksum field is unused in modern YAFFS images and is set to all-ones.
+    const NAME_CHECKSUM_UNUSED: u16 = 0xFFFF;
 
     let obj_type = read_u32(page, 0, endianness)?;
     let parent_id = read_u32(page, 4, endianness)?;
+    let name_checksum = read_u16(page, NAME_CHECKSUM_OFFSET, endianness)?;
 
-    // Mirror parse_yaffs_obj_header's sanity checks.
-    if obj_type > MAX_OBJ_TYPE || parent_id == 0 {
+    // Mirror parse_yaffs_obj_header's sanity checks, including the unused name-checksum
+    // sentinel, so corrupt pages with chunk id 0 are rejected.
+    if obj_type > MAX_OBJ_TYPE || parent_id == 0 || name_checksum != NAME_CHECKSUM_UNUSED {
         return None;
     }
 
@@ -560,6 +639,7 @@ fn parse_full_object_header(page: &[u8], endianness: Endianness) -> Option<Yaffs
         equiv_id: read_u32(page, EQUIV_ID_OFFSET, endianness).unwrap_or(0),
         mode: read_u32(page, MODE_OFFSET, endianness).unwrap_or(0),
         rdev: read_u32(page, RDEV_OFFSET, endianness).unwrap_or(0),
+        file_size: read_u32(page, FILE_SIZE_OFFSET, endianness).unwrap_or(0) as usize,
     })
 }
 
@@ -601,6 +681,15 @@ fn read_u32(data: &[u8], offset: usize, endianness: Endianness) -> Option<u32> {
     Some(match endianness {
         Endianness::Big => u32::from_be_bytes(bytes),
         Endianness::Little => u32::from_le_bytes(bytes),
+    })
+}
+
+/// Read a little/big-endian `u16` at `offset`, returning `None` if out of bounds.
+fn read_u16(data: &[u8], offset: usize, endianness: Endianness) -> Option<u16> {
+    let bytes: [u8; 2] = data.get(offset..offset + 2)?.try_into().ok()?;
+    Some(match endianness {
+        Endianness::Big => u16::from_be_bytes(bytes),
+        Endianness::Little => u16::from_le_bytes(bytes),
     })
 }
 
@@ -725,6 +814,87 @@ mod tests {
         let result = extract_yaffs(FIXTURE, 0, None);
         assert!(result.success);
         assert_eq!(result.size, Some(IMAGE_SIZE));
+    }
+
+    #[test]
+    fn nested_hardlink_resolves_to_target() {
+        // A regular file in one directory and a hardlink to it from a *different*
+        // directory, to exercise root-relative target resolution.
+        let mut objects = BTreeMap::new();
+        objects.insert(
+            10,
+            YaffsObjectInfo {
+                obj_type: 3,
+                parent_id: 1,
+                name: "d1".to_string(),
+                ..Default::default()
+            },
+        );
+        objects.insert(
+            11,
+            YaffsObjectInfo {
+                obj_type: 1,
+                parent_id: 10,
+                name: "f.txt".to_string(),
+                file_size: 5,
+                ..Default::default()
+            },
+        );
+        objects.insert(
+            12,
+            YaffsObjectInfo {
+                obj_type: 3,
+                parent_id: 1,
+                name: "d2".to_string(),
+                ..Default::default()
+            },
+        );
+        objects.insert(
+            13,
+            YaffsObjectInfo {
+                obj_type: 4,
+                parent_id: 12,
+                name: "link".to_string(),
+                equiv_id: 11,
+                ..Default::default()
+            },
+        );
+
+        let mut file_chunks: BTreeMap<u32, BTreeMap<u32, (u32, Vec<u8>)>> = BTreeMap::new();
+        let mut chunks = BTreeMap::new();
+        chunks.insert(1u32, (4096u32, b"hello".to_vec()));
+        file_chunks.insert(11, chunks);
+
+        let output = tempfile::tempdir().unwrap();
+        let chroot = Chroot::new(output.path());
+
+        for id in [10u32, 11, 12, 13] {
+            let path = resolve_object_path(id, &objects).unwrap();
+            assert!(write_object(
+                &chroot,
+                id,
+                &path,
+                &objects,
+                &mut file_chunks,
+                2048
+            ));
+        }
+
+        // The file extracted correctly...
+        assert_eq!(
+            std::fs::read_to_string(output.path().join("d1").join("f.txt")).unwrap(),
+            "hello"
+        );
+        // ...and the nested hardlink (written as a symlink) resolves back to it rather
+        // than to a path relative to its own directory.
+        let link = output.path().join("d2").join("link");
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(std::fs::read_to_string(&link).unwrap(), "hello");
     }
 
     #[test]

--- a/tests/common/snapshots/yaffs2__common__tests__yaffs2.rs-7-5_ordered_extractions.snap
+++ b/tests/common/snapshots/yaffs2__common__tests__yaffs2.rs-7-5_ordered_extractions.snap
@@ -2,8 +2,8 @@
 source: tests/common/mod.rs
 expression: ordered_extractions
 ---
-- size: ~
+- size: 126720
   success: true
-  extractor: unyaffs
+  extractor: yaffs_built_in
   do_not_recurse: false
   output_directory: "[output_directory]"


### PR DESCRIPTION
## What

Replaces the external **`unyaffs`** tool with a built-in **Rust YAFFS2 extractor**, so YAFFS2 images extract with no external dependency. Removes `unyaffs` from the `Dockerfile` and `dependencies/ubuntu.sh`.

## Why not a crate?

Per the request, I first checked for an existing Rust implementation. There is **no usable crate** for extracting YAFFS2 *images*: the only candidates are `Big-Smarty/yaffs2_fuse` (an abandoned, self-described buggy FUSE driver, 0.1.0, not on crates.io) and `sillyZAI/LibAFL_yaffs2` (a fuzzer fork, not an extractor). So `extract_yaffs()` is a **port of the `unyaffs` algorithm** (the tool Debian ships, `ehlers/unyaffs`), generalized to the page/spare geometry the existing signature parser already detects.

## How it works

Walks the image chunk-by-chunk. Each chunk is `page_size` bytes of data followed by a `spare_size` spare/OOB area; the spare begins with the packed tags `(seq, object_id, chunk_id, byte_count)`.

- `chunk_id == 0` → object header (type / parent id / name / mode / size / alias / …).
- `chunk_id == N > 0` → the N-th `page_size` data block of the file, of which `byte_count` bytes are valid (handles the partial final chunk).
- Object ids from the tags are mapped to each object's parent + name to rebuild full paths. Files, directories, symlinks, hardlinks (represented as symlinks, like the tarball extractor), and special files are written through the chroot-safe `Chroot` API, so object paths can't escape the extraction directory.

## Tests

- **Unit tests** (`src/formats/yaffs.rs`): page/spare geometry detection, object-header parsing, endianness-aware `read_u32`, NUL-terminated string reads, parent-chain path resolution (incl. orphan rejection), dry-run, and full on-disk extraction of the fixture (asserts 13 files with exact byte sizes).
- **System test** (`tests/yaffs2.rs`): unchanged; the snapshot is updated to the internal extractor (`extractor: yaffs_built_in`, with the extracted size now reported).

## Validation

Rebuilt the Docker `dev` image from this branch's Dockerfile (confirmed `unyaffs` is **absent** from the image) and ran the full CI suite inside it:

```
docker build --target dev -t binwalk:dev .
docker run --rm -v "$PWD:/tmp/binwalk" -e CI=true -e INSTA_UPDATE=new binwalk:dev \
  cargo insta test --unreferenced=reject
```

Result: **all tests pass** (lib unit incl. the new yaffs tests, the `yaffs2` system test via the internal extractor, doctests), `cargo fmt --check` clean, and `cargo clippy` clean on this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for lz4, lzop, and unrar compression formats.

* **Refactor**
  * Improved YAFFS2 extraction for better reliability, including more thorough validation of image structure and extracted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->