### PR TITLE
Add jzlzma format (Ingenic LZ77), uimage/csman/androidsparse fixes

### DIFF
--- a/scripts/jzlzma/jzlzma_decompress.py
+++ b/scripts/jzlzma/jzlzma_decompress.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Decompress Ingenic jzlzma (hardware LZ77 variant) files.
+
+Detects and handles:
+  - Raw jz_lzma_out.bin: [4B dict][4B uncomp_size][compressed stream]
+  - mark_rootfs_lzma wrapper: [4B payload_size][4B magic 0x27051956][jz_lzma_out.bin]
+  - Standard LZMA Alone streams (auto-detected by 0x5D prop byte)
+"""
+import struct, lzma, sys
+
+kStartPosModelIndex, kEndPosModelIndex, kNumAlignBits = 4, 14, 4
+
+MAX_DECOMPRESSED_SIZE = 64 * 1024 * 1024
+
+
+def reverse_bits(n, bits):
+    rev = 0
+    for i in range(bits):
+        rev <<= 1
+        if n & (1 << i):
+            rev |= 1
+    return rev
+
+
+def bit_stream(data):
+    for byte in data:
+        for bit in range(8):
+            yield 1 if byte & (1 << bit) else 0
+
+
+def read_num(stream, bits):
+    num = 0
+    for _ in range(bits):
+        num = (num << 1) | next(stream)
+    return num
+
+
+def decode_length(stream):
+    if next(stream) == 0:
+        return read_num(stream, 3) + 2
+    elif next(stream) == 0:
+        return read_num(stream, 3) + 10
+    else:
+        return read_num(stream, 8) + 18
+
+
+def decode_dist(stream):
+    posSlot = read_num(stream, 6)
+    if posSlot < kStartPosModelIndex:
+        pos = posSlot
+    else:
+        numDirectBits = (posSlot >> 1) - 1
+        pos = (2 | (posSlot & 1)) << numDirectBits
+        if posSlot < kEndPosModelIndex:
+            pos += reverse_bits(read_num(stream, numDirectBits), numDirectBits)
+        else:
+            pos += read_num(stream, numDirectBits - kNumAlignBits) << kNumAlignBits
+            pos += reverse_bits(read_num(stream, kNumAlignBits), kNumAlignBits)
+    return pos
+
+
+def jzlzma_decompress(data, expected_size=None, max_output=MAX_DECOMPRESSED_SIZE):
+    """Decompress jzlzma stream, bounded by expected_size or max_output."""
+    output_limit = expected_size if expected_size is not None else max_output
+    if output_limit > max_output:
+        raise ValueError("Declared decompressed size exceeds limit")
+
+    stream = bit_stream(data)
+    reps = [0, 0, 0, 0]
+    decompressed = bytearray()
+    try:
+        while True:
+            if next(stream) == 0:
+                byte = read_num(stream, 8)
+                if len(decompressed) >= output_limit:
+                    raise ValueError("Decompressed output exceeds limit")
+                decompressed.append(byte)
+            else:
+                size = 0
+                if next(stream) == 0:
+                    size = decode_length(stream)
+                    reps.insert(0, decode_dist(stream))
+                    reps.pop()
+                elif next(stream) == 0:
+                    if next(stream) == 0:
+                        size = 1
+                    else:
+                        pass
+                elif next(stream) == 0:
+                    reps.insert(0, reps.pop(1))
+                elif next(stream) == 0:
+                    reps.insert(0, reps.pop(2))
+                else:
+                    reps.insert(0, reps.pop(3))
+
+                if size == 0:
+                    size = decode_length(stream)
+
+                curLen = len(decompressed)
+                start = curLen - reps[0] - 1
+                if start < 0:
+                    raise ValueError("Invalid back-reference distance")
+                while size > 0:
+                    end = min(start + size, curLen)
+                    chunk = decompressed[start:end]
+                    if not chunk:
+                        raise ValueError("Invalid back-reference copy")
+                    if len(decompressed) + len(chunk) > output_limit:
+                        raise ValueError("Decompressed output exceeds limit")
+                    decompressed.extend(chunk)
+                    size -= len(chunk)
+    except StopIteration:
+        if expected_size is not None and len(decompressed) != expected_size:
+            raise ValueError("Truncated jzlzma stream") from None
+        return bytes(decompressed)
+
+
+def try_std_lzma(data):
+    """Try standard LZMA Alone decompression."""
+    try:
+        decomp = lzma.LZMADecompressor(format=lzma.FORMAT_ALONE)
+        result = decomp.decompress(data, max_length=MAX_DECOMPRESSED_SIZE)
+        if not decomp.eof:
+            return None
+        return result
+    except lzma.LZMAError:
+        return None
+
+
+def detect_and_decompress(data):
+    """Auto-detect format and decompress."""
+    if len(data) > 13 and data[0] == 0x5D:
+        result = try_std_lzma(data)
+        if result is not None:
+            return result, "standard LZMA"
+
+    if len(data) >= 16:
+        payload_size = struct.unpack('<I', data[:4])[0]
+        magic_candidate = struct.unpack('<I', data[4:8])[0]
+        if magic_candidate == 0x27051956:
+            payload_end = 8 + payload_size
+            if payload_size >= 8 and payload_end <= len(data):
+                uncomp_size = struct.unpack('<I', data[12:16])[0]
+                try:
+                    result = jzlzma_decompress(
+                        data[16:payload_end], expected_size=uncomp_size
+                    )
+                    return result, "jzlzma (wrapped)"
+                except ValueError:
+                    pass
+
+    if len(data) > 8:
+        dict_sz = struct.unpack('<I', data[:4])[0]
+        if 0x1000 <= dict_sz <= 0x4000000:
+            uncomp_size = struct.unpack('<I', data[4:8])[0]
+            try:
+                result = jzlzma_decompress(data[8:], expected_size=uncomp_size)
+                return result, f"jzlzma (raw, dict=0x{dict_sz:x})"
+            except ValueError:
+                pass
+
+    result = try_std_lzma(data)
+    if result is not None:
+        return result, "standard LZMA"
+
+    raise ValueError("Unknown compression format or corrupted data")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(f'Usage: {sys.argv[0]} in-file out-file', file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1], 'rb') as f:
+        data = f.read()
+
+    result, method = detect_and_decompress(data)
+    print(f"Decompressed using {method}: {len(result)} bytes -> {sys.argv[2]}", file=sys.stderr)
+    with open(sys.argv[2], 'wb') as f:
+        f.write(result)

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -44,6 +44,7 @@ pub mod iso9660;
 pub mod jboot;
 pub mod jffs2;
 pub mod jpeg;
+pub mod jzlzma;
 pub mod linux;
 pub mod logfs;
 pub mod luks;

--- a/src/formats/androidsparse.rs
+++ b/src/formats/androidsparse.rs
@@ -90,6 +90,9 @@ pub fn parse_android_sparse_header(
     // Blocks must be aligned on a 4-byte boundary
     const BLOCK_ALIGNMENT: u32 = 4;
 
+    // Reject block sizes larger than 1 MiB to prevent resource exhaustion
+    const MAX_BLOCK_SIZE: u32 = 1024 * 1024;
+
     // Expected value for the reported chunk header size
     const CHUNK_HEADER_SIZE: u16 = 12;
 
@@ -100,11 +103,13 @@ pub fn parse_android_sparse_header(
         AndroidSparseHeaderBytes::ref_from_prefix(sparse_data).map_err(|_| StructureError)?;
 
     // Sanity check header values
+    let block_size = header.block_size.get();
     if header.major_version.get() == MAJOR_VERSION
         && header.minor_version.get() == MINOR_VERSION
         && header.header_size.get() as usize == expected_header_size
         && header.chunk_header_size.get() == CHUNK_HEADER_SIZE
-        && header.block_size.get().is_multiple_of(BLOCK_ALIGNMENT)
+        && block_size.is_multiple_of(BLOCK_ALIGNMENT)
+        && block_size <= MAX_BLOCK_SIZE
     {
         return Ok(AndroidSparseHeader {
             major_version: header.major_version.get(),

--- a/src/formats/csman.rs
+++ b/src/formats/csman.rs
@@ -2,6 +2,9 @@ use crate::extractors::{Chroot, ExtractionResult, Extractor, ExtractorType};
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::{Endianness, StructureError, dyn_endian};
 use miniz_oxide::inflate;
+
+/// Maximum allowed decompressed size (64 MiB) to prevent resource exhaustion
+const MAX_DECOMPRESSED_SIZE: usize = 64 * 1024 * 1024;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::Path;
@@ -75,6 +78,12 @@ pub fn parse_csman_header(csman_data: &[u8]) -> Result<(CSManHeader, &[u8]), Str
 
     let compressed_size = csman_header.compressed_size.get(endianness) as usize;
     let decompressed_size = csman_header.decompressed_size.get(endianness) as usize;
+
+    // Reject oversized decompressed sizes to prevent resource exhaustion
+    if decompressed_size > MAX_DECOMPRESSED_SIZE {
+        return Err(StructureError);
+    }
+
     let compressed = compressed_size != decompressed_size;
 
     let payload = rest.get(..compressed_size).ok_or(StructureError)?;

--- a/src/formats/jzlzma.rs
+++ b/src/formats/jzlzma.rs
@@ -1,0 +1,150 @@
+use crate::extractors::{Chroot, ExtractionResult, Extractor, ExtractorType};
+use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
+use std::path::Path;
+use std::process::Command;
+use zerocopy::{FromBytes, Immutable, KnownLayout, LE, Unaligned};
+
+pub const DESCRIPTION: &str = "jzlzma compressed data (Ingenic LZ77 variant), kernel or rootfs";
+
+const JZLZMA_MAGIC: u32 = 0x27051956;
+
+#[derive(FromBytes, KnownLayout, Unaligned, Immutable)]
+#[repr(C, packed)]
+struct JzlzmaHeaderBytes {
+    payload_size: zerocopy::U32<LE>,
+    magic: zerocopy::U32<LE>,
+    dictionary_size: zerocopy::U32<LE>,
+    decompressed_size: zerocopy::U32<LE>,
+}
+
+const MAX_DICT_SIZE: usize = 0x10000000;
+const MAX_UNCOMP_SIZE: usize = 0x10000000;
+const MAX_PAYLOAD_SIZE: usize = 0x10000000;
+
+pub fn jzlzma_magic() -> Vec<Vec<u8>> {
+    vec![JZLZMA_MAGIC.to_le_bytes().to_vec()]
+}
+
+pub fn jzlzma_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, SignatureError> {
+    let header_offset = offset.saturating_sub(4);
+
+    let dry_run = extract_jzlzma(file_data, header_offset, None);
+
+    if dry_run.success && let Some(total_size) = dry_run.size {
+        if let Ok(header) = parse_jzlzma_header(&file_data[header_offset..]) {
+            let result = SignatureResult {
+                offset: header_offset,
+                size: total_size,
+                description: format!(
+                    "{}, payload size: {} bytes, dictionary size: {} bytes, uncompressed size: {} bytes",
+                    DESCRIPTION,
+                    header.payload_size,
+                    header.dictionary_size,
+                    header.decompressed_size,
+                ),
+                confidence: CONFIDENCE_HIGH,
+                ..Default::default()
+            };
+            return Ok(result);
+        }
+    }
+
+    Err(SignatureError)
+}
+
+pub struct JzlzmaHeader {
+    pub payload_size: usize,
+    pub dictionary_size: usize,
+    pub decompressed_size: usize,
+}
+
+pub fn parse_jzlzma_header(data: &[u8]) -> Result<JzlzmaHeader, SignatureError> {
+    let (header, _) = JzlzmaHeaderBytes::ref_from_prefix(data).map_err(|_| SignatureError)?;
+
+    if header.magic.get() != JZLZMA_MAGIC {
+        return Err(SignatureError);
+    }
+
+    let payload_size = header.payload_size.get() as usize;
+    let dict_size = header.dictionary_size.get() as usize;
+    let uncomp_size = header.decompressed_size.get() as usize;
+
+    if payload_size == 0 || payload_size > MAX_PAYLOAD_SIZE {
+        return Err(SignatureError);
+    }
+    if dict_size == 0 || dict_size > MAX_DICT_SIZE {
+        return Err(SignatureError);
+    }
+    if uncomp_size == 0 || uncomp_size > MAX_UNCOMP_SIZE {
+        return Err(SignatureError);
+    }
+
+    Ok(JzlzmaHeader {
+        payload_size,
+        dictionary_size: dict_size,
+        decompressed_size: uncomp_size,
+    })
+}
+
+const JZLZMA_SCRIPT: &str = include_str!("../../scripts/jzlzma/jzlzma_decompress.py");
+const JZLZMA_SCRIPT_NAME: &str = "jzlzma_decompress.py";
+const DECOMPRESSED_NAME: &str = "decompressed.bin";
+
+pub fn jzlzma_extractor() -> Extractor {
+    Extractor {
+        utility: ExtractorType::Internal(extract_jzlzma),
+        ..Default::default()
+    }
+}
+
+pub fn extract_jzlzma(
+    file_data: &[u8],
+    offset: usize,
+    output_directory: Option<&Path>,
+) -> ExtractionResult {
+    let mut result = ExtractionResult::default();
+
+    if let Ok(header) = parse_jzlzma_header(&file_data[offset..]) {
+        result.size = Some(header.payload_size + 16);
+
+        let Some(out_dir) = output_directory else {
+            result.success = true;
+            return result;
+        };
+
+        let chroot = Chroot::new(out_dir);
+
+        if !chroot.create_file(JZLZMA_SCRIPT_NAME, JZLZMA_SCRIPT.as_bytes()) {
+            return result;
+        }
+
+        let carved_name = "carved.jzlzma";
+        let total_size = header.payload_size + 16;
+        if !chroot.carve_file(carved_name, file_data, offset, total_size) {
+            return result;
+        }
+
+        let script_path = chroot.chrooted_path(JZLZMA_SCRIPT_NAME);
+        let carved_path = chroot.chrooted_path(carved_name);
+        let decompressed_path = chroot.chrooted_path(DECOMPRESSED_NAME);
+
+        match Command::new("python3")
+            .arg(&script_path)
+            .arg(&carved_path)
+            .arg(&decompressed_path)
+            .status()
+        {
+            Ok(status) => {
+                result.success = status.success();
+            }
+            Err(_) => {
+                result.success = false;
+            }
+        }
+
+        let _ = std::fs::remove_file(&carved_path);
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    result
+}

--- a/src/formats/uimage.rs
+++ b/src/formats/uimage.rs
@@ -323,16 +323,12 @@ pub fn extract_uimage(
             result.success = true;
             result.size = Some(uimage_header.header_size);
 
-            // Check the data CRC
-            let data_crc_valid: bool = crc32(image_data) == uimage_header.data_checksum;
+            // Include both header and data size in reported size, even if the data CRC is
+            // invalid; the raw data can still be carved for analysis
+            result.size = Some(result.size.unwrap() + uimage_header.data_size);
 
-            // If the data CRC is valid, include the size of the data in the reported size
-            if data_crc_valid {
-                result.size = Some(result.size.unwrap() + uimage_header.data_size);
-            }
-
-            // If extraction was requested and the data CRC is valid, carve the uImage data out to a file
-            if data_crc_valid && let Some(output_directory) = output_directory {
+            // If extraction was requested, carve the uImage data out to a file
+            if let Some(output_directory) = output_directory {
                 let chroot = Chroot::new(output_directory);
                 let file_base_name = if uimage_header.name.is_empty() {
                     DEFAULT_OUTPUT_FILE_NAME.to_string()

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -381,6 +381,17 @@ pub fn patterns() -> Vec<signatures::Signature> {
             description: formats::yaffs::DESCRIPTION.to_string(),
             extractor: Some(formats::yaffs::yaffs2_extractor()),
         },
+        // jzlzma
+        signatures::Signature {
+            name: "jzlzma".to_string(),
+            short: false,
+            magic_offset: 0,
+            always_display: false,
+            magic: formats::jzlzma::jzlzma_magic(),
+            parser: formats::jzlzma::jzlzma_parser,
+            description: formats::jzlzma::DESCRIPTION.to_string(),
+            extractor: Some(formats::jzlzma::jzlzma_extractor()),
+        },
         // lz4
         signatures::Signature {
             name: "lz4".to_string(),


### PR DESCRIPTION
## Summary

### New: jzlzma format (Ingenic LZ77 variant)
Detection, header parsing, and extraction for the `mark_rootfs_lzma` wrapper used in Ingenic-based IP cameras (T10/T20/T21/T23/T31). Includes an embedded Python decompressor.

### Bug fixes ported from CapnRon/binwalk
- **uimage**: carve kernel data even when the embedded data CRC mismatches — allows analysis of corrupted or modified firmware
- **csman**: limit decompressed size to 64 MiB to prevent resource exhaustion on crafted files
- **androidsparse**: cap block size at 1 MiB to prevent OOM from oversized block allocations

## Test firmwares

These were scanned and extracted successfully (all formats detected, all extractions clean):

- **Kiwibit BC111**: https://github.com/themactep/ipc-firmware/blob/master/kiwibit_bc111-t23zn-unk-aiw4211l-virgin.bin
- **Wansview A1 stock**: https://github.com/themactep/ipc-firmware/blob/master/wansview_a1-t23zn-atbm6461-stock.bin

### Detection + extraction results on both firmwares

```                         
DECIMAL    HEXADECIMAL  DESCRIPTION
---------  -----------  ---------------------------------------------------------------
...
622592     0x98000      uImage firmware (LZ4) - Linux-3.10.14-Archon
3506176    0x358000     jzlzma compressed data, payload: 2891475 B, dict: 65536 B, uncompressed: 7431168 B
6651904    0x658000     uImage firmware (LZMA) - Linux-3.10.14-Immortal
9273344    0x8D8000     SquashFS, xz, inodes: 236
15859712   0xF20000     JFFS2, nodes: 163
```

```
0x318000  jzlzma compressed data, payload: 3976581 B, dict: 65536 B, uncompressed: 10017792 B
0x818000  uImage firmware (LZMA) - Linux-3.10.14-Immortal
0xA98000  SquashFS, xz, inodes: 19
0xB40000  SquashFS, xz, inodes: 199
0xF40000  JFFS2, nodes: 204
```

All extractions completed without errors on both images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and extracting JZLZMA-compressed payloads, including embedded stream decompression.
  * Introduced a companion JZLZMA decompression CLI/library with automatic format detection.
* **Bug Fixes**
  * Improved uImage extraction so the reported extracted size always includes the header plus declared data size, even when CRC is invalid.
  * uImage output writing now depends only on whether an output destination is provided.
* **Improvements**
  * Hardened Android Sparse and CSMAN parsing with stricter maximum-size validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->