### PR TITLE
fix(zip): check magic in header parser and treat EOF as valid archive end

### DIFF
--- a/src/formats/dahua_zip.rs
+++ b/src/formats/dahua_zip.rs
@@ -7,11 +7,13 @@ use std::path::Path;
 /// Human readable description
 pub const DESCRIPTION: &str = "Dahua ZIP archive";
 
+// The first ZIP file entry in the Dahua ZIP file is has "DH" instead of "PK".
+// Otherwise, it is a normal ZIP file.
+pub(crate) const DAHUA_ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"DH\x03\x04";
+
 /// Dahua ZIP file entry magic bytes
 pub fn dahua_zip_magic() -> Vec<Vec<u8>> {
-    // The first ZIP file entry in the Dahua ZIP file is has "DH" instead of "PK".
-    // Otherwise, it is a normal ZIP file.
-    vec![b"DH\x03\x04".to_vec()]
+    vec![DAHUA_ZIP_LOCAL_FILE_MAGIC.to_vec()]
 }
 
 /// Validates a Dahua ZIP file entry signature

--- a/src/formats/zip.rs
+++ b/src/formats/zip.rs
@@ -39,7 +39,7 @@ pub fn zip_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
             }
             // If the ZIP file is corrupted and no EOCD header exists, attempt to parse all the individual ZIP file headers
             Err(_) => {
-                let available_data = file_data.len() - offset;
+                let available_data = file_data.len();
                 let mut previous_file_header_offset = None;
                 let mut next_file_header_offset = offset + zip_file_header.total_size;
 

--- a/src/formats/zip.rs
+++ b/src/formats/zip.rs
@@ -43,6 +43,7 @@ pub fn zip_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
                 let mut previous_file_header_offset = None;
                 let mut next_file_header_offset = offset + zip_file_header.total_size;
 
+                // Walk, consuming zip entries until we find an invalid one, or end of file
                 while is_offset_safe(
                     available_data,
                     next_file_header_offset,
@@ -53,19 +54,18 @@ pub fn zip_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
                             previous_file_header_offset = Some(next_file_header_offset);
                             next_file_header_offset += zip_header.total_size;
                         }
-                        Err(_) => {
-                            result.size = next_file_header_offset - offset;
-                            result.description = format!(
-                                "{}, version: {}.{}, missing end-of-central-directory header, total size: {} bytes",
-                                result.description,
-                                zip_file_header.version_major,
-                                zip_file_header.version_minor,
-                                result.size
-                            );
-                            break;
-                        }
+                        Err(_) => break,
                     }
                 }
+
+                result.size = next_file_header_offset.min(file_data.len()) - offset;
+                result.description = format!(
+                    "{}, version: {}.{}, missing end-of-central-directory header, total size: {} bytes",
+                    result.description,
+                    zip_file_header.version_major,
+                    zip_file_header.version_minor,
+                    result.size
+                );
             }
         }
 
@@ -123,7 +123,7 @@ pub struct ZipFileHeader {
 #[derive(FromBytes, KnownLayout, Unaligned, Immutable)]
 #[repr(C, packed)]
 struct ZipHeaderBytes {
-    magic: zerocopy::U32<LE>,
+    magic: [u8; 4],
     version: zerocopy::U16<LE>,
     flags: zerocopy::U16<LE>,
     compression: zerocopy::U16<LE>,
@@ -138,6 +138,12 @@ struct ZipHeaderBytes {
 
 /// Validate a ZIP file header
 pub fn parse_zip_header(zip_data: &[u8]) -> Result<ZipFileHeader, StructureError> {
+    // Local file header magic bytes, "PK\x03\x04"
+    const ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"PK\x03\x04";
+
+    // Dahua ZIP files replace the magic bytes of the first local file header with "DH\x03\x04"
+    const DAHUA_ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"DH\x03\x04";
+
     // Unused flag bits
     const UNUSED_FLAGS_MASK: u16 = 0b11010111_10000000;
 
@@ -174,6 +180,12 @@ pub fn parse_zip_header(zip_data: &[u8]) -> Result<ZipFileHeader, StructureError
     // Parse the ZIP local file structure
     let (zip_local_file_header, _) =
         ZipHeaderBytes::ref_from_prefix(zip_data).map_err(|_| StructureError)?;
+
+    // The magic bytes must match a ZIP local file header (or the Dahua ZIP variant)
+    let magic = zip_local_file_header.magic;
+    if magic != ZIP_LOCAL_FILE_MAGIC && magic != DAHUA_ZIP_LOCAL_FILE_MAGIC {
+        return Err(StructureError);
+    }
 
     // Unused/reserved flag bits should be 0
     if (zip_local_file_header.flags & UNUSED_FLAGS_MASK) == 0 {

--- a/src/formats/zip.rs
+++ b/src/formats/zip.rs
@@ -1,4 +1,5 @@
 use crate::common::is_offset_safe;
+use crate::formats::dahua_zip::DAHUA_ZIP_LOCAL_FILE_MAGIC;
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::StructureError;
 use aho_corasick::AhoCorasick;
@@ -7,9 +8,11 @@ use zerocopy::{FromBytes, Immutable, KnownLayout, LE, Unaligned};
 /// Human readable description
 pub const DESCRIPTION: &str = "ZIP archive";
 
+const ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"PK\x03\x04";
+
 /// ZIP file entry magic bytes
 pub fn zip_magic() -> Vec<Vec<u8>> {
-    vec![b"PK\x03\x04".to_vec()]
+    vec![ZIP_LOCAL_FILE_MAGIC.to_vec()]
 }
 
 /// Validates a ZIP file entry signature
@@ -138,12 +141,6 @@ struct ZipHeaderBytes {
 
 /// Validate a ZIP file header
 pub fn parse_zip_header(zip_data: &[u8]) -> Result<ZipFileHeader, StructureError> {
-    // Local file header magic bytes, "PK\x03\x04"
-    const ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"PK\x03\x04";
-
-    // Dahua ZIP files replace the magic bytes of the first local file header with "DH\x03\x04"
-    const DAHUA_ZIP_LOCAL_FILE_MAGIC: [u8; 4] = *b"DH\x03\x04";
-
     // Unused flag bits
     const UNUSED_FLAGS_MASK: u16 = 0b11010111_10000000;
 

--- a/tests/common/snapshots/zip_truncated__common__tests__zip_truncated.rs-7-5_file_map.snap
+++ b/tests/common/snapshots/zip_truncated__common__tests__zip_truncated.rs-7-5_file_map.snap
@@ -4,9 +4,9 @@ expression: results.file_map
 ---
 - offset: 0
   id: "[uuid]"
-  size: 353993
+  size: 353954
   name: zip
   confidence: 250
-  description: "ZIP archive, version: 1.0, missing end-of-central-directory header, total size: 353993 bytes"
+  description: "ZIP archive, version: 1.0, missing end-of-central-directory header, total size: 353954 bytes"
   always_display: false
   extraction_declined: false


### PR DESCRIPTION
The ZIP local file header parser accepted any bytes whose flag and compression fields happened to be valid, without checking the `PK\x03\x04` magic. Combined with the fallback walk (used when no end-of-central-directory record is found) only succeeding when it eventually hit an unparseable header, this produced O(n^2) behavior: a run of trailing zero bytes parsed as an endless sequence of "valid" headers, so every candidate ZIP offset re-scanned the entire remainder of the file and none ever succeeded.
    
Two fixes:
    
1. parse_zip_header now verifies the local file header magic (accepting the Dahua "DH\x03\x04" variant as well), so zero/garbage bytes are rejected immediately. This could have allowed the zip parser to have consumed way too much data.
2. The fallback header walk now treats reaching EOF as a successful end of the archive rather than requiring an invalid header to appear. Size is the walked extent clamped to the available data.
    
The truncated-zip snapshot size shifts from 353993 to 353954, which is the correct boundary: the walk now stops exactly at the central directory (`PK\x01\x02`) instead of mis-reading it as another local file header.

Fixes #79
Fixes https://github.com/ReFirmLabs/binwalk/issues/962 (in binwalk-ng)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP parsing resilience by recovering when the end-of-central-directory header is missing, by scanning subsequent local file headers to determine safe bounds.
  * Added support for Dahua-produced ZIP variants by expanding and validating the ZIP local-file header “magic” values during header parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->