### PR TITLE
Add crc32 check to arj, add more fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -613,9 +613,9 @@ dependencies = [
 [[package]]
 name = "delink"
 version = "0.1.0"
-source = "git+https://github.com/binwalk-ng/delink#18ed41c5948bfb2970c9ed04a73be03912d8db6b"
+source = "git+https://github.com/binwalk-ng/delink#d0b28bdc411482662c6273e83645223db1023e1b"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "cbc",
  "env_logger",
  "hex",
@@ -694,9 +694,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1323,9 +1323,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -1504,7 +1504,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b93c196fb1a6b7b9a199597340339907ab62aab6d6b5d3d14bfdcae8d5003fa"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "aho-corasick",
  "getrandom 0.4.3",
  "hmac 0.13.0",
@@ -1650,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1744,7 +1744,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",

--- a/src/formats/arj.rs
+++ b/src/formats/arj.rs
@@ -98,8 +98,7 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
     let basic_hdr_size = arj_header.basic_hdr_size.get() as usize;
 
     // Minimum header data block size (excluding magic + basic_hdr_size)
-    const HDR_PREFIX_SIZE: usize = std::mem::size_of::<zerocopy::U16<LE>>() * 2;
-    const MIN_HDR_SIZE: usize = std::mem::size_of::<ARJHeaderBytes>() - HDR_PREFIX_SIZE;
+    const MIN_HDR_SIZE: usize = std::mem::size_of::<ARJHeaderBytes>() - HDR_DATA_OFFSET;
     const CRC_SIZE: usize = std::mem::size_of::<u32>();
 
     if basic_hdr_size < MIN_HDR_SIZE || HDR_DATA_OFFSET + basic_hdr_size + CRC_SIZE > arj_data.len()

--- a/src/formats/arj.rs
+++ b/src/formats/arj.rs
@@ -193,7 +193,7 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
 
     // Filename starts at first_hdr_size within the header data block
     let original_name = arj_data
-        .get(HDR_DATA_OFFSET + first_hdr_size..)
+        .get(HDR_DATA_OFFSET + first_hdr_size..crc_start)
         .map_or_else(|| "".to_string(), get_cstring);
 
     Ok(ARJHeader {

--- a/src/formats/arj.rs
+++ b/src/formats/arj.rs
@@ -99,8 +99,9 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
 
     // Minimum header data block size (excluding magic + basic_hdr_size)
     const HDR_PREFIX_SIZE: usize = std::mem::size_of::<zerocopy::U16<LE>>() * 2;
-    const CRC_SIZE: usize = std::mem::size_of::<u32>();
     const MIN_HDR_SIZE: usize = std::mem::size_of::<ARJHeaderBytes>() - HDR_PREFIX_SIZE;
+    const CRC_SIZE: usize = std::mem::size_of::<u32>();
+
     if basic_hdr_size < MIN_HDR_SIZE || HDR_DATA_OFFSET + basic_hdr_size + CRC_SIZE > arj_data.len()
     {
         return Err(StructureError);
@@ -197,7 +198,7 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
         .map_or_else(|| "".to_string(), get_cstring);
 
     Ok(ARJHeader {
-        header_size: first_hdr_size,
+        header_size: HDR_DATA_OFFSET + basic_hdr_size + CRC_SIZE,
         version: arj_header.archiver_version,
         min_version: arj_header.min_version,
         flags,

--- a/src/formats/arj.rs
+++ b/src/formats/arj.rs
@@ -1,5 +1,5 @@
-use crate::common::{epoch_to_string, get_cstring};
-use crate::signatures::{CONFIDENCE_MEDIUM, SignatureError, SignatureResult};
+use crate::common::{crc32, epoch_to_string, get_cstring};
+use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::StructureError;
 use zerocopy::{FromBytes, Immutable, KnownLayout, LE, Unaligned};
 
@@ -9,37 +9,45 @@ pub fn arj_magic() -> Vec<Vec<u8>> {
 }
 
 pub fn arj_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, SignatureError> {
-    if let Ok(arj_header) = parse_arj_header(&file_data[offset..]) {
-        let available_data = file_data.len() - offset;
-        // Sanity check the reported ARJ header size
-        if arj_header.header_size <= available_data {
-            // Return success
-            return Ok(SignatureResult {
-                description: format!(
-                    "{}, header size: {}, version {}, minimum version to extract: {}, flags: {}, compression method: {}, file type: {}, original name: {}, original file date: {}, compressed file size: {}, uncompressed file size: {}, os: {}",
-                    DESCRIPTION,
-                    arj_header.header_size,
-                    arj_header.version,
-                    arj_header.min_version,
-                    arj_header.flags,
-                    arj_header.compression_method,
-                    arj_header.file_type,
-                    arj_header.original_name,
-                    arj_header.original_file_date,
-                    arj_header.compressed_file_size,
-                    arj_header.uncompressed_file_size,
-                    arj_header.host_os,
-                ),
-                offset,
-                size: arj_header.header_size,
-                confidence: CONFIDENCE_MEDIUM,
-                extraction_declined: arj_header.file_type != *"comment header",
-                ..Default::default()
-            });
-        }
+    let arj_header = match parse_arj_header(&file_data[offset..]) {
+        Ok(h) => h,
+        Err(_) => return Err(SignatureError),
+    };
+
+    let available_data = file_data.len() - offset;
+    if arj_header.header_size > available_data {
+        return Err(SignatureError);
     }
 
-    Err(SignatureError)
+    // Verify the header CRC
+    let data = &file_data[offset..];
+    let header_data = &data[HDR_DATA_OFFSET..HDR_DATA_OFFSET + arj_header.basic_hdr_size];
+    if crc32(header_data) != arj_header.header_crc {
+        return Err(SignatureError);
+    }
+
+    Ok(SignatureResult {
+        description: format!(
+            "{}, header size: {}, version {}, minimum version to extract: {}, flags: {}, compression method: {}, file type: {}, original name: {}, original file date: {}, compressed file size: {}, uncompressed file size: {}, os: {}",
+            DESCRIPTION,
+            arj_header.header_size,
+            arj_header.version,
+            arj_header.min_version,
+            arj_header.flags,
+            arj_header.compression_method,
+            arj_header.file_type,
+            arj_header.original_name,
+            arj_header.original_file_date,
+            arj_header.compressed_file_size,
+            arj_header.uncompressed_file_size,
+            arj_header.host_os,
+        ),
+        offset,
+        size: arj_header.header_size,
+        confidence: CONFIDENCE_HIGH,
+        extraction_declined: arj_header.file_type != *"comment header",
+        ..Default::default()
+    })
 }
 
 #[derive(Debug, Default, Clone)]
@@ -55,36 +63,65 @@ pub struct ARJHeader {
     pub original_file_date: String,
     pub compressed_file_size: usize,
     pub uncompressed_file_size: usize,
+    pub basic_hdr_size: usize,
+    pub header_crc: u32,
 }
 
-// ARJ header structure (https://www.fileformat.info/format/arj/corion.htm)
 #[derive(FromBytes, KnownLayout, Unaligned, Immutable)]
 #[repr(C, packed)]
 struct ARJHeaderBytes {
-    magic: zerocopy::U16<LE>,               // offset 0x00
-    basic_header_size: zerocopy::U16<LE>,   // offset 0x02
-    extra_header_size: u8,                  // offset 0x04
-    archiver_version: u8,                   // offset 0x05
-    min_version: u8,                        // offset 0x06
-    host_os: u8,                            // offset 0x07
-    internal_flags: u8,                     // offset 0x08
-    compression_method: u8,                 // offset 0x09
-    file_type: u8,                          // offset 0x0A
-    reserved1: u8,                          // offset 0x0B
-    datetime_file: zerocopy::U32<LE>,       // offset 0x0C
-    compressed_filesize: zerocopy::I32<LE>, // offset 0x10
-    original_filesize: zerocopy::I32<LE>,   // offset 0x14
+    magic: zerocopy::U16<LE>,
+    basic_hdr_size: zerocopy::U16<LE>,
+    first_hdr_size: u8,
+    archiver_version: u8,
+    min_version: u8,
+    host_os: u8,
+    internal_flags: u8,
+    compression_method: u8,
+    file_type: u8,
+    password_modifier: u8,
+    datetime_file: zerocopy::U32<LE>,
+    compressed_filesize: zerocopy::I32<LE>,
+    original_filesize: zerocopy::I32<LE>,
+    original_file_crc32: zerocopy::U32<LE>,
+    entry_pos: zerocopy::U16<LE>,
+    file_attributes: zerocopy::U16<LE>,
+    ext_flags: u8,
+    chapter_number: u8,
 }
+
+const HDR_DATA_OFFSET: usize = std::mem::offset_of!(ARJHeaderBytes, first_hdr_size);
 
 pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
     let (arj_header, _) = ARJHeaderBytes::ref_from_prefix(arj_data).map_err(|_| StructureError)?;
-    // check the version information in the header
+
+    let basic_hdr_size = arj_header.basic_hdr_size.get() as usize;
+
+    // Minimum header data block size (excluding magic + basic_hdr_size)
+    const HDR_PREFIX_SIZE: usize = std::mem::size_of::<zerocopy::U16<LE>>() * 2;
+    const CRC_SIZE: usize = std::mem::size_of::<u32>();
+    const MIN_HDR_SIZE: usize = std::mem::size_of::<ARJHeaderBytes>() - HDR_PREFIX_SIZE;
+    if basic_hdr_size < MIN_HDR_SIZE || HDR_DATA_OFFSET + basic_hdr_size + CRC_SIZE > arj_data.len()
+    {
+        return Err(StructureError);
+    }
+
+    // Header CRC is stored after the variable-length header data block, so it can't be part of the fixed-size struct
+    let crc_start = HDR_DATA_OFFSET + basic_hdr_size;
+    let header_crc = u32::from_le_bytes(
+        arj_data[crc_start..crc_start + CRC_SIZE]
+            .try_into()
+            .expect("bad slice"),
+    );
+
+    // Validate version range
     if !(1..=16).contains(&arj_header.archiver_version)
         || !(1..=16).contains(&arj_header.min_version)
         || arj_header.archiver_version < arj_header.min_version
     {
         return Err(StructureError);
     }
+
     let mut flags = match arj_header.internal_flags & 0x01 {
         0 => "no password".to_string(),
         _ => "password".to_string(),
@@ -92,42 +129,53 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
     if arj_header.internal_flags & 0x04 != 0 {
         flags = format!("{flags}|multi-volume");
     }
-    // let file_start_pos_is_available =  arj_header.internal_flags & 0x08 != 0;
+
     if arj_header.internal_flags & 0x10 != 0 {
         flags = format!("{flags}|slash-switched");
     }
     if arj_header.internal_flags & 0x20 != 0 {
         flags = format!("{flags}|backup");
     }
-    let host_os = match &arj_header.host_os {
-        0 => "MS-DOS".to_string(),
-        1 => "PRIMOS".to_string(),
-        2 => "UNIX".to_string(),
-        3 => "AMIGA".to_string(),
-        4 => "MAX-OS".to_string(),
-        5 => "OS/2".to_string(),
-        6 => "APPLE GS".to_string(),
-        7 => "ATARI ST".to_string(),
-        8 => "NeXT".to_string(),
-        9 => "VAX VMS".to_string(),
+
+    let host_os = match arj_header.host_os {
+        0 => "MS-DOS",
+        1 => "PRIMOS",
+        2 => "UNIX",
+        3 => "AMIGA",
+        4 => "MAX-OS",
+        5 => "OS/2",
+        6 => "APPLE GS",
+        7 => "ATARI ST",
+        8 => "NeXT",
+        9 => "VAX VMS",
+        10 => "WIN95",
+        11 => "WINNT",
         _ => return Err(StructureError),
-    };
-    let compression_method = match &arj_header.compression_method {
-        0 => "stored".to_string(),
-        1 => "compressed most".to_string(),
-        2 => "compressed".to_string(),
-        3 => "compressed faster".to_string(),
-        4 => "compressed fastest".to_string(),
+    }
+    .to_string();
+
+    let compression_method = match arj_header.compression_method {
+        0 => "stored",
+        1 => "compressed most",
+        2 => "compressed",
+        3 => "compressed faster",
+        4 => "compressed fastest",
         _ => return Err(StructureError),
-    };
-    let file_type = match &arj_header.file_type {
-        0 => "binary".to_string(),
-        1 => "7-bit text".to_string(),
-        2 => "comment header".to_string(),
-        3 => "directory".to_string(),
-        4 => "volume label".to_string(),
+    }
+    .to_string();
+
+    let file_type = match arj_header.file_type {
+        0 => "binary",
+        1 => "7-bit text",
+        2 => "comment header",
+        3 => "directory",
+        4 => "volume label",
+        5 => "chapter",
+        6 => "UNIX special",
         _ => return Err(StructureError),
-    };
+    }
+    .to_string();
+
     let compressed_file_size = arj_header.compressed_filesize.get();
     if compressed_file_size < 0 {
         return Err(StructureError);
@@ -137,13 +185,19 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
         return Err(StructureError);
     }
 
-    let header_size = arj_header.extra_header_size as usize;
+    // first_hdr_size is the offset within the header data block to the filename
+    let first_hdr_size = arj_header.first_hdr_size as usize;
+    if first_hdr_size < MIN_HDR_SIZE || first_hdr_size >= basic_hdr_size {
+        return Err(StructureError);
+    }
+
+    // Filename starts at first_hdr_size within the header data block
     let original_name = arj_data
-        .get(header_size + 4..)
+        .get(HDR_DATA_OFFSET + first_hdr_size..)
         .map_or_else(|| "".to_string(), get_cstring);
 
     Ok(ARJHeader {
-        header_size,
+        header_size: first_hdr_size,
         version: arj_header.archiver_version,
         min_version: arj_header.min_version,
         flags,
@@ -154,5 +208,7 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
         original_file_date: epoch_to_string(arj_header.datetime_file.get()),
         compressed_file_size: compressed_file_size as usize,
         uncompressed_file_size: uncompressed_file_size as usize,
+        basic_hdr_size,
+        header_crc,
     })
 }

--- a/src/formats/arj.rs
+++ b/src/formats/arj.rs
@@ -143,7 +143,7 @@ pub fn parse_arj_header(arj_data: &[u8]) -> Result<ARJHeader, StructureError> {
         1 => "PRIMOS",
         2 => "UNIX",
         3 => "AMIGA",
-        4 => "MAX-OS",
+        4 => "MAC-OS",
         5 => "OS/2",
         6 => "APPLE GS",
         7 => "ATARI ST",

--- a/tests/common/snapshots/arj__common__tests__arj.rs-15-5_file_map.snap
+++ b/tests/common/snapshots/arj__common__tests__arj.rs-15-5_file_map.snap
@@ -6,7 +6,7 @@ expression: results.file_map
   id: "[uuid]"
   size: 34
   name: arj
-  confidence: 128
+  confidence: 250
   description: "ARJ archive data, header size: 34, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: stored, file type: comment header, original name: example.arj, original file date: 2025-02-23 14:49:02, compressed file size: 1740322564, uncompressed file size: 0, os: UNIX"
   always_display: false
   extraction_declined: false
@@ -14,7 +14,7 @@ expression: results.file_map
   id: "[uuid]"
   size: 46
   name: arj
-  confidence: 128
+  confidence: 250
   description: "ARJ archive data, header size: 46, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: compressed most, file type: binary, original name: secret.txt, original file date: 2025-02-23 14:56:01, compressed file size: 54, uncompressed file size: 60, os: UNIX"
   always_display: false
   extraction_declined: true

--- a/tests/common/snapshots/arj__common__tests__arj.rs-15-5_file_map.snap
+++ b/tests/common/snapshots/arj__common__tests__arj.rs-15-5_file_map.snap
@@ -4,17 +4,17 @@ expression: results.file_map
 ---
 - offset: 13
   id: "[uuid]"
-  size: 34
+  size: 55
   name: arj
   confidence: 250
-  description: "ARJ archive data, header size: 34, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: stored, file type: comment header, original name: example.arj, original file date: 2025-02-23 14:49:02, compressed file size: 1740322564, uncompressed file size: 0, os: UNIX"
+  description: "ARJ archive data, header size: 55, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: stored, file type: comment header, original name: example.arj, original file date: 2025-02-23 14:49:02, compressed file size: 1740322564, uncompressed file size: 0, os: UNIX"
   always_display: false
   extraction_declined: false
 - offset: 70
   id: "[uuid]"
-  size: 46
+  size: 66
   name: arj
   confidence: 250
-  description: "ARJ archive data, header size: 46, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: compressed most, file type: binary, original name: secret.txt, original file date: 2025-02-23 14:56:01, compressed file size: 54, uncompressed file size: 60, os: UNIX"
+  description: "ARJ archive data, header size: 66, version 11, minimum version to extract: 1, flags: no password|slash-switched, compression method: compressed most, file type: binary, original name: secret.txt, original file date: 2025-02-23 14:56:01, compressed file size: 54, uncompressed file size: 60, os: UNIX"
   always_display: false
   extraction_declined: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARJ archive detection by tightening header parsing and raising confidence for verified archives.
  * Added stricter header size bounds to avoid processing incomplete data.
  * Introduced header CRC verification to reduce false positives from corrupted headers.
  * Corrected filename and header-field extraction to use the proper offsets within the header data.
  * More consistently rejects malformed or truncated ARJ headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->