### PR TITLE
perf(scan): use a signature reference, rather than a clone

### DIFF
--- a/src/binwalk_ng.rs
+++ b/src/binwalk_ng.rs
@@ -356,11 +356,10 @@ impl Binwalk {
 
                 // Get the signature associated with this magic signature
                 let magic_pattern_index = magic_match.pattern().as_usize();
-                let signature: signatures::Signature = self
+                let signature: &signatures::Signature = self
                     .pattern_signature_table
                     .get(&magic_pattern_index)
-                    .unwrap()
-                    .clone();
+                    .unwrap();
 
                 debug!(
                     "Found {} magic match at offset {:#X}",
@@ -383,7 +382,7 @@ impl Binwalk {
                     }
 
                     // Auto populate some signature result fields
-                    signature_result_auto_populate(&mut signature_result, &signature);
+                    signature_result_auto_populate(&mut signature_result, signature);
 
                     // Add this signature to the file map
                     file_map.push(signature_result.clone());


### PR DESCRIPTION
This was taking an appreciable (~10%) amount of time, and is totally unnecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary copying while processing matched file signatures, improving scan efficiency without changing results or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->