### PR TITLE
feat(io): read files via mmap, with --no-mmap opt-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "lzfse",
  "md-5",
  "memchr",
+ "memmap2",
  "miniz_oxide 0.9.1",
  "plotly",
  "rars",
@@ -1185,6 +1186,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rars = "0.4.0"
 tar = "0.4"
 zstd = "0.13.3"
 lz4_flex = "0.14.0"
+memmap2 = "0.9.9"
 
 [dependencies.uuid]
 version = "1.23.4"

--- a/src/binwalk_ng.rs
+++ b/src/binwalk_ng.rs
@@ -16,7 +16,7 @@ use std::os::windows;
 #[cfg(unix)]
 use std::os::unix;
 
-use crate::common::{is_offset_safe, read_file};
+use crate::common::{is_offset_safe, read_or_map_file};
 use crate::extractors;
 use crate::magic;
 use crate::signatures;
@@ -83,6 +83,11 @@ pub struct Binwalk {
     pub pattern_signature_table: HashMap<usize, signatures::Signature>,
     /// Maps signatures to their corresponding extractors
     pub extractor_lookup_table: HashMap<String, Option<extractors::Extractor>>,
+    /// If the mmap call is allowed to be used for reading files
+    ///
+    /// Binwalk may abort unexpectedly if mmap is used and the analyzed file(s) are simultaneously
+    /// truncated.
+    pub allow_mmap: bool,
 }
 
 impl Binwalk {
@@ -137,7 +142,10 @@ impl Binwalk {
         signatures: Option<Vec<signatures::Signature>>,
         full_search: bool,
     ) -> Result<Self, BinwalkError> {
-        let mut new_instance = Self::default();
+        let mut new_instance = Self {
+            allow_mmap: true,
+            ..Default::default()
+        };
 
         // Target file is optional, especially if being called via the library
         if let Some(target_file) = target_file_name {
@@ -775,12 +783,16 @@ impl Binwalk {
     pub fn analyze(&self, target_file: impl AsRef<Path>, do_extraction: bool) -> AnalysisResults {
         let file_path = target_file.as_ref();
 
-        let file_data = read_file(file_path).unwrap_or_else(|_| {
-            error!("Failed to read data from {}", file_path.display());
-            b"".to_vec()
-        });
+        let file_data = read_or_map_file(file_path, self.allow_mmap);
+        let file_data: &[u8] = file_data
+            .as_ref()
+            .map(|data| data.as_ref())
+            .unwrap_or_else(|_| {
+                error!("Failed to read data from {}", file_path.display());
+                b""
+            });
 
-        self.analyze_buf(&file_data, file_path, do_extraction)
+        self.analyze_buf(file_data, file_path, do_extraction)
     }
 }
 

--- a/src/cli_parser.rs
+++ b/src/cli_parser.rs
@@ -87,4 +87,11 @@ pub struct CliArgs {
     /// Extract files/folders to a custom directory
     #[arg(short, long, default_value = "extractions", value_hint = clap::ValueHint::DirPath)]
     pub directory: PathBuf,
+
+    /// Disable the use of memory maps
+    ///
+    /// binwalk may abort unexpectedly when memory maps are used if it searches a file that is
+    /// simultaneously truncated. Users can opt out of this possibility by disabling memory maps.
+    #[arg(long)]
+    pub no_mmap: bool,
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -33,10 +33,7 @@ pub fn read_file(file: impl AsRef<Path>) -> Result<Vec<u8>, std::io::Error> {
     Ok(file_data)
 }
 
-pub fn read_or_map_file<'a>(
-    file: &Path,
-    allow_mmap: bool,
-) -> std::io::Result<impl AsRef<[u8]> + 'a> {
+pub fn read_or_map_file(file: &Path, allow_mmap: bool) -> std::io::Result<impl AsRef<[u8]>> {
     let mut f = std::fs::File::open(file)?;
     if allow_mmap && let Ok(map) = unsafe { Mmap::map(&f) } {
         Ok(VecOrMmap::Mmap(map))

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,8 @@
 //! Common Functions
+
 use log::{debug, error};
+use memmap2::Mmap;
+use std::io::Read;
 use std::path::Path;
 
 /// Read a file data into memory and return its contents.
@@ -28,6 +31,34 @@ pub fn read_file(file: impl AsRef<Path>) -> Result<Vec<u8>, std::io::Error> {
     let file_size = file_data.len();
     debug!("Loaded {file_size} bytes from {}", file_path.display());
     Ok(file_data)
+}
+
+pub fn read_or_map_file<'a>(
+    file: &Path,
+    allow_mmap: bool,
+) -> std::io::Result<impl AsRef<[u8]> + 'a> {
+    let mut f = std::fs::File::open(file)?;
+    if allow_mmap && let Ok(map) = unsafe { Mmap::map(&f) } {
+        Ok(VecOrMmap::Mmap(map))
+    } else {
+        let mut v = Vec::new();
+        f.read_to_end(&mut v)?;
+        Ok(VecOrMmap::Vec(v))
+    }
+}
+
+enum VecOrMmap {
+    Vec(Vec<u8>),
+    Mmap(Mmap),
+}
+
+impl AsRef<[u8]> for VecOrMmap {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Vec(v) => v,
+            Self::Mmap(map) => map,
+        }
+    }
 }
 
 /// Calculates the CRC32 checksum of the given data.

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> ExitCode {
     }
 
     // Initialize binwalk
-    let binwalker = match binwalk_ng::Binwalk::configure(
+    let mut binwalker = match binwalk_ng::Binwalk::configure(
         cli_args.file_name.as_deref(),
         output_directory.as_deref(),
         cli_args.include,
@@ -123,6 +123,7 @@ fn main() -> ExitCode {
         }
         Ok(bw) => bw,
     };
+    binwalker.allow_mmap = !cli_args.no_mmap;
     let binwalker = Arc::new(binwalker);
 
     // If the user specified --threads, honor that request; else, auto-detect available parallelism
@@ -343,17 +344,21 @@ fn spawn_worker(
     pending.fetch_add(1, Ordering::Release);
     pool.spawn(move || {
         // Read in file data
-        let file_data = common::read_file(&target_file).unwrap_or_else(|_| {
-            error!("Failed to read {} data", target_file.display());
-            b"".to_vec()
-        });
+        let file_data = common::read_or_map_file(&target_file, bw.allow_mmap);
+        let file_data: &[u8] = file_data
+            .as_ref()
+            .map(|data| data.as_ref())
+            .unwrap_or_else(|_| {
+                error!("Failed to read {} data", target_file.display());
+                b""
+            });
 
         // Analyze target file, with extraction, if specified
-        let results = bw.analyze_buf(&file_data, &target_file, do_extraction);
+        let results = bw.analyze_buf(file_data, &target_file, do_extraction);
 
         // If data carving was requested as part of extraction, carve analysis results to disk
         if do_carve {
-            let carve_count = carve_file_map(&file_data, &results);
+            let carve_count = carve_file_map(file_data, &results);
             info!(
                 "Carved {carve_count} data blocks to disk from {}",
                 target_file.display()


### PR DESCRIPTION
Add `read_or_map_file`, which memory-maps the target file when allowed and falls back to reading it into a Vec if mapping fails. `Binwalk::analyze` and the worker pool in main.rs now borrow the mapped bytes instead of owning a Vec, avoiding a full copy of every analyzed file.

`Binwalk::configure` enables mmap by default; the CLI turns it back off for `--no-mmap`, since a file truncated while it is mapped will abort the process.

See also https://github.com/ReFirmLabs/binwalk/pull/762

I don't have any explanation for how mmap would lead to the behavior seen there. I think we should just see if anyone else ever sees something like that.

This should reduce the memory footprint required, e.g. related to #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional memory-mapped file loading to speed up analysis.
  * Added a `--no-mmap` option to disable memory mapping.
* **Bug Fixes**
  * Improved robustness by falling back to standard loading (or an empty buffer on failure) when mapping/reading fails.
* **Chores**
  * Added the `memmap2` dependency to support memory mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->