### PR TITLE
fix(main): share the Binwalk instance across workers via Arc to avoid OOM

### DIFF
--- a/src/cli_parser.rs
+++ b/src/cli_parser.rs
@@ -61,7 +61,7 @@ pub struct CliArgs {
 
     /// Manually specify the number of threads to use
     #[arg(short, long, value_name = "INT", value_parser = clap::value_parser!(u64).range(1..))]
-    pub threads: Option<usize>,
+    pub threads: Option<u64>,
 
     /// Do not scan for these signatures
     #[arg(

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1402,7 +1402,13 @@ pub fn execute(
                     }
 
                     ExtractorType::Internal(func) => {
-                        debug!("Executing internal {} extractor", signature.name);
+                        debug!(
+                            "Executing internal {} extractor on {} @ {} (size:{})",
+                            signature.name,
+                            file_path.as_ref().display(),
+                            signature.offset,
+                            signature.size,
+                        );
                         // Run the internal extractor function
                         result = func(file_data, signature.offset, Some(&output_directory));
                         // Set the extractor name to "<signature name>_built_in"

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,7 @@ fn main() -> ExitCode {
         }
         Ok(bw) => bw,
     };
+    let binwalker = Arc::new(binwalker);
 
     // If the user specified --threads, honor that request; else, auto-detect available parallelism
     let available_workers = cli_args.threads.map(|t| t as usize).unwrap_or_else(|| {
@@ -331,7 +332,7 @@ fn process_analysis_results(
 /// Spawn a worker thread to analyze a file
 fn spawn_worker(
     pool: &ThreadPool,
-    bw: binwalk_ng::Binwalk,
+    bw: Arc<binwalk_ng::Binwalk>,
     target_file: impl AsRef<Path>,
     do_extraction: bool,
     do_carve: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn main() -> ExitCode {
     };
 
     // If the user specified --threads, honor that request; else, auto-detect available parallelism
-    let available_workers = cli_args.threads.unwrap_or_else(|| {
+    let available_workers = cli_args.threads.map(|t| t as usize).unwrap_or_else(|| {
         // Get CPU core info
         match thread::available_parallelism() {
             // In case of error use the default


### PR DESCRIPTION
The main loop drains every discovered file into the rayon pool in one go, and each spawned task took its own `Binwalk` clone. That clone is a deep copy of the signature database: `pattern_signature_table` holds a full `Signature`, magic byte vectors included, per pattern, measuring ~252 KiB of heap for the default signatures / patterns.

Rayon's injector queue is unbounded, so the number of live clones is the number of files discovered but not yet analyzed. A recursive extraction makes that large all at once: `get_extracted_files` returns every regular file in an extracted tree, so unpacking a rootfs queues tens of thousands of tasks, each carrying its own copy of the database.

Wrap the instance in an `Arc` so a queued task carries a pointer rather than a copy. Analyzing a 10 MB tar of 10,000 small files with `--threads=1` drops peak RSS from 2.22 GB to 26.5 MB, with byte-for-byte identical extraction output. This also is just faster: it's less work to increment an atomic counter vs cloning everything in a Binwalk struct.

Note this shrinks the per-task cost but does not bound the queue itself; the backlog is still unbounded, at roughly 100 bytes per pending task.

This is almost certainly what the comment at https://github.com/binwalk-ng/binwalk-ng/pull/59#discussion_r3517582770 was talking about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the supported range for manually configured thread counts.

* **Bug Fixes**
  * Improved compatibility when distributing work across multiple threads.

* **Diagnostics**
  * Enhanced debug logging with signature details, input file, extraction offset, and size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->