### PR TITLE
fix(svg): don't require the xmlns magic to terminate an image

### DIFF
--- a/src/formats/svg.rs
+++ b/src/formats/svg.rs
@@ -3,13 +3,14 @@ use crate::signatures::{CONFIDENCE_MEDIUM, SignatureError, SignatureResult};
 use crate::structures::StructureError;
 use aho_corasick::AhoCorasick;
 use std::path::Path;
+use std::sync::LazyLock;
 
 /// Human readable description
 pub const DESCRIPTION: &str = "SVG image";
 
 /// SVG magic bytes
 pub fn svg_magic() -> Vec<Vec<u8>> {
-    vec![b"<svg ".to_vec()]
+    vec![SVG_OPEN_TAG.as_bytes().to_vec()]
 }
 
 /// Parse an SVG image
@@ -25,7 +26,7 @@ pub fn svg_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
     // Perform an extraction dry-run
     let dry_run = extract_svg_image(file_data, offset, None);
 
-    // If the dry-run was a success, this is probably a valid JPEG file
+    // If the dry-run was a success, this is probably a valid SVG file
     if dry_run.success {
         // Get the total size of the SVG
         if let Some(svg_size) = dry_run.size {
@@ -45,9 +46,8 @@ pub fn svg_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
     Err(SignatureError)
 }
 
-const SVG_OPEN_TAG: &[u8] = b"<svg ";
-const SVG_CLOSE_TAG: &[u8] = b"</svg>";
-const SVG_HEAD_MAGIC: &str = "xmlns=\"http://www.w3.org/2000/svg\"";
+const SVG_OPEN_TAG: &str = "<svg ";
+const SVG_CLOSE_TAG: &str = "</svg>";
 
 /// Stores info about an SVG image
 #[derive(Debug, Default, Clone)]
@@ -55,82 +55,47 @@ pub struct SVGImage {
     pub total_size: usize,
 }
 
+const SVG_TAGS: [&str; 2] = [SVG_OPEN_TAG, SVG_CLOSE_TAG];
+const OPEN_PATTERN: usize = 0;
+const CLOSE_PATTERN: usize = 1;
+static SVG_OPEN_CLOSE_TAG_PATTERNS: LazyLock<AhoCorasick> =
+    LazyLock::new(|| AhoCorasick::new(SVG_TAGS).unwrap());
+
 /// Parse an SVG image to determine its total size
 pub fn parse_svg_image(svg_data: &[u8]) -> Result<SVGImage, StructureError> {
-    let mut head_tag_count: usize = 0;
-    let mut unclosed_svg_tags: usize = 0;
+    let mut offset = 0;
+    let mut depth = 0usize;
 
-    let svg_tags = vec![SVG_OPEN_TAG, SVG_CLOSE_TAG];
-
-    let grep = AhoCorasick::new(svg_tags).unwrap();
+    let grep: &AhoCorasick = &SVG_OPEN_CLOSE_TAG_PATTERNS;
 
     // Need to search through the data to find all <svg ...> and </svg> tags.
     // There may be multiple of these tags in any given SVG image.
-    for tag_match in grep.find_overlapping_iter(svg_data) {
-        let tag_start = tag_match.start();
-
-        match parse_svg_tag(&svg_data[tag_start..]) {
-            Err(_) => {
-                break;
-            }
-            Ok(svg_tag) => {
-                if svg_tag.is_head {
-                    head_tag_count += 1;
-                }
-
-                if svg_tag.is_open {
-                    unclosed_svg_tags += 1;
-                }
-
-                if svg_tag.is_close {
-                    unclosed_svg_tags -= 1;
-                }
-
-                // There should be only one head tag
-                if head_tag_count > 1 {
+    while let Some(tag_match) = grep.find(aho_corasick::Input::new(svg_data).range(offset..)) {
+        if str::from_utf8(&svg_data[offset..tag_match.start()]).is_err() {
+            // Only allow UTF-8 contents, don't accidentally consume binary data
+            break;
+        };
+        offset = match tag_match.pattern().as_usize() {
+            OPEN_PATTERN => {
+                // Make sure the tag closes
+                let Some(tag_len) = memchr::memchr(b'>', &svg_data[tag_match.end()..]) else {
+                    break;
+                };
+                if str::from_utf8(&svg_data[tag_match.end()..][..tag_len]).is_err() {
+                    // Only allow UTF-8 contents, don't accidentally consume binary data
                     break;
                 }
-
-                // If one head tag was found and all svg tags are closed, that's EOF
-                if head_tag_count == 1 && unclosed_svg_tags == 0 {
-                    return Ok(SVGImage {
-                        total_size: tag_start + SVG_CLOSE_TAG.len(),
-                    });
-                }
+                depth += 1;
+                tag_match.end() + tag_len + 1
             }
-        }
-    }
-
-    Err(StructureError)
-}
-
-/// Stores info about a parsed SVG tag
-#[derive(Debug, Default, Clone)]
-struct SVGTag {
-    pub is_head: bool,
-    pub is_open: bool,
-    pub is_close: bool,
-}
-
-/// Parse an individual SVG tag
-fn parse_svg_tag(tag_data: &[u8]) -> Result<SVGTag, StructureError> {
-    const END_TAG: u8 = 0x3E;
-
-    let svg_open_tag = String::from_utf8(SVG_OPEN_TAG.to_vec()).unwrap();
-    let svg_close_tag = String::from_utf8(SVG_CLOSE_TAG.to_vec()).unwrap();
-    let svg_head_string = SVG_HEAD_MAGIC.to_string();
-
-    // Tags are expected to start with '<svg' or </svg>', and end with '>'
-    for i in 0..tag_data.len() {
-        if tag_data[i] == END_TAG
-            && let Some(tag_bytes) = tag_data.get(0..i + 1)
-            && let Ok(tag_string) = String::from_utf8(tag_bytes.to_vec())
-        {
-            return Ok(SVGTag {
-                is_head: tag_string.contains(&svg_head_string),
-                is_open: tag_string.starts_with(&svg_open_tag),
-                is_close: tag_string.starts_with(&svg_close_tag),
-            });
+            CLOSE_PATTERN => {
+                depth = depth.checked_sub(1).ok_or(StructureError)?;
+                tag_match.end()
+            }
+            _ => unreachable!(),
+        };
+        if depth == 0 {
+            return Ok(SVGImage { total_size: offset });
         }
     }
 


### PR DESCRIPTION
parse_svg_image already tracked open/close tag depth, but only returned a size when depth hit zero *and* it had seen an opening tag containing `xmlns="http://www.w3.org/2000/svg"`. Images that declare the namespace through an XML entity (`xmlns="&ns_svg;"`, as emitted by Adobe Illustrator) never satisfy that check, so the depth-zero exit was unreachable: the parser sailed past its own balanced closing tag and kept scanning every following image to EOF before returning StructureError. Since `<svg ` is also the signature magic, every image in a blob got its own full scan of the remainder, making extraction O(n^2) in file size and stalling on large firmware images. I'm okay not requiring the xmlns declaration, just requiring properly nested tags.

Drop the head-magic condition and return at the close tag that balances the opening one. Tag contents are checked as UTF-8 while scanning so binary data isn't consumed as part of an image, the interior of each opening tag is skipped rather than searched, and the Aho-Corasick automaton is built once in a LazyLock rather than per call.

Fixes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG parsing for UTF-8 content and nested SVG elements.
  * Added validation for properly terminated opening tags.
  * SVG files with unmatched closing tags are now rejected.
  * Improved SVG file type detection and parser accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->