### PR TITLE
use memchr::memmem instead of AhoCorasick when searching for a single pattern

### DIFF
--- a/src/formats/dmg.rs
+++ b/src/formats/dmg.rs
@@ -1,7 +1,7 @@
 use crate::extractors;
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::StructureError;
-use aho_corasick::AhoCorasick;
+use memchr::memmem;
 use zerocopy::{BE, FromBytes, Immutable, KnownLayout, Unaligned};
 
 /// Human readable description
@@ -67,14 +67,11 @@ fn find_xml_property_list(file_data: &[u8]) -> Option<usize> {
     const MIN_XML_LENGTH: usize = 1024;
     const BLKX_KEY: &str = "<key>blkx</key>";
 
-    let grep = AhoCorasick::new(vec![XML_SIGNATURE]).unwrap();
-
-    for xml_match in grep.find_overlapping_iter(file_data) {
-        let xml_start = xml_match.start();
+    for xml_start in memmem::find_iter(file_data, XML_SIGNATURE.as_bytes()) {
         let xml_end = xml_start + MIN_XML_LENGTH;
 
         if let Some(xml_data) = file_data.get(xml_start..xml_end)
-            && let Ok(xml_string) = String::from_utf8(xml_data.to_vec())
+            && let Ok(xml_string) = str::from_utf8(xml_data)
             && xml_string.contains(BLKX_KEY)
         {
             return Some(xml_start);

--- a/src/formats/jffs2.rs
+++ b/src/formats/jffs2.rs
@@ -1,8 +1,8 @@
 use crate::extractors;
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::{Endianness, StructureError, dyn_endian};
-use aho_corasick::AhoCorasick;
 use crc32fast::Hasher;
+use memchr::memmem;
 use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 
 /// Human readable description
@@ -60,13 +60,10 @@ pub fn jffs2_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, 
                 Endianness::Little => JFFS2_LITTLE_ENDIAN_MAGIC,
             };
 
-            // Need to grep for all JFFS2 nodes to figure out how big this file system really is
-            let grep = AhoCorasick::new(vec![node_magic]).unwrap();
-
             // Find all matching JFFS2 node magic bytes
-            for magic_match in grep.find_overlapping_iter(&file_data[grep_offset..]) {
+            for magic_start in memmem::find_iter(&file_data[grep_offset..], node_magic) {
                 // Calculate the start and end of the node header inside the file data
-                let header_start: usize = grep_offset + magic_match.start();
+                let header_start: usize = grep_offset + magic_start;
                 let header_end: usize = header_start + JFFS2_NODE_STRUCT_SIZE;
 
                 // This is a false positive that is inside the node data of a previously validated node

--- a/src/formats/linux.rs
+++ b/src/formats/linux.rs
@@ -2,7 +2,7 @@ use crate::common::get_cstring;
 use crate::extractors;
 use crate::signatures::{CONFIDENCE_LOW, CONFIDENCE_MEDIUM, SignatureError, SignatureResult};
 use crate::structures::{Endianness, StructureError};
-use aho_corasick::AhoCorasick;
+use memchr::memmem;
 use zerocopy::{FromBytes, Immutable, KnownLayout, LE, Unaligned};
 
 /// Human readable descriptions
@@ -202,12 +202,12 @@ pub fn linux_kernel_version_parser(
 /// Searches the file data for a linux symbol table
 fn has_linux_symbol_table(file_data: &[u8]) -> bool {
     // Same magic bytes that vmlinux-to-elf searches for
-    let symtab_magic = vec![b"\x000\x001\x002\x003\x004\x005\x006\x007\x008\x009\x00"];
+    const SYMTAB_MAGIC: &[u8] = b"\x000\x001\x002\x003\x004\x005\x006\x007\x008\x009\x00";
 
-    let grep = AhoCorasick::new(symtab_magic).unwrap();
+    let mut iter = memmem::find_iter(file_data, SYMTAB_MAGIC);
 
-    // Grep for matches on the Linux symbol table magic bytes, there should be only one match
-    grep.find_overlapping_iter(file_data).count() == 1
+    // there should be only one match
+    iter.next().is_some() && iter.next().is_none()
 }
 
 /// Struct to store linux ARM64 boot image header info

--- a/src/formats/pem.rs
+++ b/src/formats/pem.rs
@@ -4,6 +4,7 @@ use aho_corasick::AhoCorasick;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use std::path::Path;
+use std::sync::LazyLock;
 
 /// Human readable descriptions
 pub const PEM_PUBLIC_KEY_DESCRIPTION: &str = "PEM public key";
@@ -259,36 +260,33 @@ pub fn pem_carver(
     result
 }
 
+const PEM_EOF_MARKERS: &[&[u8]] = &[
+    b"-----END PUBLIC KEY-----",
+    b"-----END CERTIFICATE-----",
+    b"-----END PRIVATE KEY-----",
+    b"-----END EC PRIVATE KEY-----",
+    b"-----END RSA PRIVATE KEY-----",
+    b"-----END DSA PRIVATE KEY-----",
+    b"-----END OPENSSH PRIVATE KEY-----",
+];
+
+static PEM_EOF_GREP: LazyLock<AhoCorasick> =
+    LazyLock::new(|| AhoCorasick::new(PEM_EOF_MARKERS).unwrap());
+
 fn get_pem_size(file_data: &[u8], start_of_pem_offset: usize) -> Option<usize> {
-    const EOF_MARKERS: [&[u8]; 7] = [
-        b"-----END PUBLIC KEY-----",
-        b"-----END CERTIFICATE-----",
-        b"-----END PRIVATE KEY-----",
-        b"-----END EC PRIVATE KEY-----",
-        b"-----END RSA PRIVATE KEY-----",
-        b"-----END DSA PRIVATE KEY-----",
-        b"-----END OPENSSH PRIVATE KEY-----",
-    ];
-
-    let newline_chars = [0x0D, 0x0A];
-
-    let grep = AhoCorasick::new(EOF_MARKERS).unwrap();
-
     // Find the first end marker
-    if let Some(eof_match) = grep
+    if let Some(eof_match) = PEM_EOF_GREP
         .find_overlapping_iter(&file_data[start_of_pem_offset..])
         .next()
     {
-        let eof_marker_index = eof_match.pattern().as_usize();
-        let mut pem_size = eof_match.start() + EOF_MARKERS[eof_marker_index].len();
+        let mut pem_size = eof_match.end();
 
         // Include any trailing newline characters in the total size of the PEM file
-        while (start_of_pem_offset + pem_size) < file_data.len() {
-            if newline_chars.contains(&file_data[start_of_pem_offset + pem_size]) {
-                pem_size += 1;
-            } else {
-                break;
-            }
+        while file_data
+            .get(start_of_pem_offset + pem_size)
+            .is_some_and(|&ch| ch == b'\n' || ch == b'\r')
+        {
+            pem_size += 1;
         }
 
         return Some(pem_size);

--- a/src/formats/ubi.rs
+++ b/src/formats/ubi.rs
@@ -2,7 +2,7 @@ use crate::common::crc32;
 use crate::extractors;
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::StructureError;
-use aho_corasick::AhoCorasick;
+use memchr::memmem;
 use std::collections::HashMap;
 use zerocopy::{BE, FromBytes, Immutable, KnownLayout, LE, Unaligned};
 
@@ -75,21 +75,19 @@ pub fn ubi_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, Si
 
 /// Determines the LEB size and returns the size of the UBI image
 fn get_ubi_image_size(ubi_data: &[u8]) -> Result<usize, SignatureError> {
+    // Volume magic bytes, version is assumed to be 1
+    const VOLUME_MAGIC: &[u8] = b"UBI!\x01";
+
     let mut leb_size: usize = 0;
     let mut block_count: usize = 0;
     let mut best_leb_match_count: usize = 0;
     let mut previous_volume_offset: usize = 0;
     let mut possible_leb_sizes: HashMap<usize, usize> = HashMap::new();
 
-    // Volume magic bytes, version is assumed to be 1
-    let ubi_vol_magic = vec![b"UBI!\x01"];
-
-    let grep = AhoCorasick::new(ubi_vol_magic).unwrap();
-
     // grep for all volume header magic bytes
-    for magic_match in grep.find_overlapping_iter(ubi_data) {
+    for magic_start in memmem::find_iter(ubi_data, VOLUME_MAGIC) {
         // Offset in the UBI image where this magic match was found
-        let this_volume_offset = magic_match.start();
+        let this_volume_offset = magic_start;
 
         // Parse the volume header
         if parse_ubi_volume_header(&ubi_data[this_volume_offset..]).is_ok() {

--- a/src/formats/zip.rs
+++ b/src/formats/zip.rs
@@ -2,7 +2,7 @@ use crate::common::is_offset_safe;
 use crate::formats::dahua_zip::DAHUA_ZIP_LOCAL_FILE_MAGIC;
 use crate::signatures::{CONFIDENCE_HIGH, SignatureError, SignatureResult};
 use crate::structures::StructureError;
-use aho_corasick::AhoCorasick;
+use memchr::memmem;
 use zerocopy::{FromBytes, Immutable, KnownLayout, LE, Unaligned};
 
 /// Human readable description
@@ -91,13 +91,10 @@ pub fn find_zip_eof(file_data: &[u8], offset: usize) -> Result<ZipEOCDInfo, Sign
     // This magic string assumes that the disk_number and central_directory_disk_number are 0
     const ZIP_EOCD_MAGIC: &[u8; 8] = b"PK\x05\x06\x00\x00\x00\x00";
 
-    // Instatiate AhoCorasick search with the ZIP EOCD magic bytes
-    let grep = AhoCorasick::new(vec![ZIP_EOCD_MAGIC]).unwrap();
-
     // Find all matching ZIP EOCD patterns
-    for eocd_match in grep.find_overlapping_iter(&file_data[offset..]) {
+    for eocd_start in memmem::find_iter(&file_data[offset..], ZIP_EOCD_MAGIC) {
         // Calculate the start and end of the fixed-size portion of the ZIP EOCD header in the file data
-        let eocd_start: usize = eocd_match.start() + offset;
+        let eocd_start: usize = eocd_start + offset;
 
         // Parse the end-of-central-directory header
         if let Some(eocd_data) = file_data.get(eocd_start..)


### PR DESCRIPTION
Addition to #103 