### PR TITLE
fix: Use commit SHA to look up PR instead of relying on workflow_run.pull_requests

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -15,8 +15,7 @@ jobs:
   report:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0]
+      github.event.workflow_run.event == 'pull_request'
 
     runs-on: ubuntu-latest
 
@@ -49,11 +48,24 @@ jobs:
         with:
           script: |
             const postComment = require('./.github/scripts/post-bench-comment.js');
+            const { owner, repo } = context.repo;
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+
+            const pr = prs.find((p) => p.state === 'open');
+            if (!pr) {
+              console.log('No open PR found for this commit, skipping comment.');
+              return;
+            }
 
             await postComment({
               github,
               context,
-              prNumber: context.payload.workflow_run.pull_requests[0].number,
+              prNumber: pr.number,
             });
 
       - name: Fail on regressions

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -49,23 +49,25 @@ jobs:
           script: |
             const postComment = require('./.github/scripts/post-bench-comment.js');
             const { owner, repo } = context.repo;
+            const headOwner = context.payload.workflow_run.head_repository.owner.login;
+            const headBranch = context.payload.workflow_run.head_branch;
 
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            const prs = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,
-              commit_sha: context.payload.workflow_run.head_sha,
+              state: 'open',
+              head: `${headOwner}:${headBranch}`,
             });
 
-            const pr = prs.find((p) => p.state === 'open');
-            if (!pr) {
-              console.log('No open PR found for this commit, skipping comment.');
+            if (prs.length !== 1) {
+              console.log(`Expected exactly one open PR for ${headOwner}:${headBranch}, found ${prs.length}. Skipping comment.`);
               return;
             }
 
             await postComment({
               github,
               context,
-              prNumber: pr.number,
+              prNumber: prs[0].number,
             });
 
       - name: Fail on regressions


### PR DESCRIPTION
- Remove unreliable `pull_requests[0]` check from job condition
- Use GitHub API to find open PR associated with commit SHA
- Gracefully skip comment if no open PR is found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark report handling for successful pull request runs.
  * Benchmark comments now target the correct open pull request when exactly one matching pull request is found.
  * Reports no longer require embedded pull request details to identify a target.
  * Commenting is safely skipped when no matching pull request—or multiple matches—are found, with the outcome recorded for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->